### PR TITLE
Allow custom source-tree dirname

### DIFF
--- a/bin/pitivi-env
+++ b/bin/pitivi-env
@@ -14,12 +14,13 @@ SCRIPT=${BASH_SOURCE[0]:-$0}
 SCRIPTDIR=$(dirname $(realpath $SCRIPT))
 export FLATPAK_ENVPATH=$(realpath $SCRIPTDIR/../../)
 export CURRENT_GST=$FLATPAK_ENVPATH
+PITIVI_INSTALL_PATH=$(realpath $SCRIPTDIR/../)
 
 # Use ptvenv for running commands in the sandbox.
-alias ptvenv="$FLATPAK_ENVPATH/pitivi/build/flatpak/pitivi-flatpak -d"
+alias ptvenv="$PITIVI_INSTALL_PATH/build/flatpak/pitivi-flatpak -d"
 
 echo "-> Setting up environment if needed..."
-$FLATPAK_ENVPATH/pitivi/build/flatpak/pitivi-flatpak -q -d echo
+$PITIVI_INSTALL_PATH/build/flatpak/pitivi-flatpak -q -d echo
 if [ "$?" = "0" ];
 then
     # Set up environment variables and aliases so configuring, building, etc.
@@ -35,15 +36,15 @@ then
     alias minstall=$minstall
     alias autogen=$autogen
     alias configure=$configure
-    alias ninja="$FLATPAK_ENVPATH/pitivi/build/flatpak/pitivi-flatpak -q -d ninja"
+    alias ninja="$PITIVI_INSTALL_PATH/build/flatpak/pitivi-flatpak -q -d ninja"
 
     # Prefer to run the binaries in the sandbox. For example "python3".
-    for i in `$FLATPAK_ENVPATH/pitivi/build/flatpak/pitivi-flatpak -q -d ls /app/bin/`;
+    for i in `$PITIVI_INSTALL_PATH/build/flatpak/pitivi-flatpak -q -d ls /app/bin/`;
     do
         alias $i="ptvenv $i"
     done
 
-    alias pitivi="ptvenv $FLATPAK_ENVPATH/pitivi/bin/pitivi"
+    alias pitivi="ptvenv $PITIVI_INSTALL_PATH/bin/pitivi"
 
     export PS1="(ptv-flatpak) $PS1"
     export PATH="$FLATPAK_ENVPATH/bin/:$PATH"

--- a/bin/pitivi-env
+++ b/bin/pitivi-env
@@ -11,16 +11,16 @@ SCRIPT=${BASH_SOURCE[0]:-$0}
     && echo \
     && exit 1
 
-SCRIPTDIR=$(dirname $(realpath $SCRIPT))
-export FLATPAK_ENVPATH=$(realpath $SCRIPTDIR/../../)
+SCRIPT_DIR=$(dirname $(realpath $SCRIPT))
+PITIVI_REPO_DIR=$(realpath $SCRIPT_DIR/..)
+export FLATPAK_ENVPATH=$(realpath $PITIVI_REPO_DIR/..)
 export CURRENT_GST=$FLATPAK_ENVPATH
-PITIVI_INSTALL_PATH=$(realpath $SCRIPTDIR/../)
 
 # Use ptvenv for running commands in the sandbox.
-alias ptvenv="$PITIVI_INSTALL_PATH/build/flatpak/pitivi-flatpak -d"
+alias ptvenv="$PITIVI_REPO_DIR/build/flatpak/pitivi-flatpak -d"
 
 echo "-> Setting up environment if needed..."
-$PITIVI_INSTALL_PATH/build/flatpak/pitivi-flatpak -q -d echo
+$PITIVI_REPO_DIR/build/flatpak/pitivi-flatpak -q -d echo
 if [ "$?" = "0" ];
 then
     # Set up environment variables and aliases so configuring, building, etc.
@@ -36,15 +36,15 @@ then
     alias minstall=$minstall
     alias autogen=$autogen
     alias configure=$configure
-    alias ninja="$PITIVI_INSTALL_PATH/build/flatpak/pitivi-flatpak -q -d ninja"
+    alias ninja="$PITIVI_REPO_DIR/build/flatpak/pitivi-flatpak -q -d ninja"
 
     # Prefer to run the binaries in the sandbox. For example "python3".
-    for i in `$PITIVI_INSTALL_PATH/build/flatpak/pitivi-flatpak -q -d ls /app/bin/`;
+    for i in `$PITIVI_REPO_DIR/build/flatpak/pitivi-flatpak -q -d ls /app/bin/`;
     do
         alias $i="ptvenv $i"
     done
 
-    alias pitivi="ptvenv $PITIVI_INSTALL_PATH/bin/pitivi"
+    alias pitivi="ptvenv $PITIVI_REPO_DIR/bin/pitivi"
 
     export PS1="(ptv-flatpak) $PS1"
     export PATH="$FLATPAK_ENVPATH/bin/:$PATH"


### PR DESCRIPTION
The `bin/pitivi-env` script has several lines like:  
(for instance, a line that runs `pitivi-flatpak`) 
`$FLATPAK_ENVPATH/pitivi/build/flatpak/pitivi-flatpak ...`

These lines assume that the user downloaded the Pitivi source into a folder called `pitivi`.  

I wanted to name that folder after the version number of Pitivi, `pitivi-0.98`.  

The attached commit introduces a variable called `PITIVI_INSTALL_PATH` which allows that.  

Edit:  Variable name changed to PITIVI_REPO_DIR as requested by `aleb`.  