### PR TITLE
Misc. typos

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -139,7 +139,7 @@
   * Integrated offline user manual
   * Cleaner advanced codec settings dialog
   * Improved video thumbnailing performance
-  * "Soft depedencies" manager to warn the user of features requiring additional packages
+  * "Soft dependencies" manager to warn the user of features requiring additional packages
   * Port to gtkbuilder
   * Respect GNOME's button icons setting
   * Improved startup time

--- a/build/flatpak/pitivi-flatpak
+++ b/build/flatpak/pitivi-flatpak
@@ -380,7 +380,7 @@ class PitiviFlatpak:  # pylint: disable=too-many-instance-attributes
         except FileNotFoundError:
             Console.message("\n%sYou need to install flatpak >= %s"
                             " to be able to use the '%s' script.\n\n"
-                            "You can find some informations about"
+                            "You can find some information about"
                             " how to install it for your distribution at:\n"
                             "    * http://flatpak.org/%s\n", Colors.FAIL,
                             FLATPAK_REQ, sys.argv[0], Colors.ENDC)

--- a/docs/Feroze_gsoc.md
+++ b/docs/Feroze_gsoc.md
@@ -32,7 +32,7 @@ codecs or would have to google it up.
 
 `   1. The user should just be able to click on the output format and render. This would enable us to expand the userbase to people without much codec knowledge.`\
 `   2. User can add, remove and rename presets and edit codec settings within the render dialog menu.`\
-`   3. The presets should be stored seperately and the user should be able to import and export presets from GUI.`\
+`   3. The presets should be stored separately and the user should be able to import and export presets from GUI.`\
 `   4. Enable us to bundle a default set of rendering and project setting presets`
 
 Presets Suggested : iPod , iPad, PlayStation 3, DVD (NTSC, PAL), HTML5 (

--- a/docs/Google_SoC_2007_-_Simple_Timeline.md
+++ b/docs/Google_SoC_2007_-_Simple_Timeline.md
@@ -94,7 +94,7 @@ implementing the file format (which is the hard/interesting part).
 
 I've been working on the design documents, and creating file/load save
 test cases. My goal is to have the application logic for file load/save
-comitted to the SoC branch some time next week. I've been focusing
+committed to the SoC branch some time next week. I've been focusing
 mostly on design at the moment. Today I spent some time splitting up the
 design docs page into separate elements. I also am having to compile
 GStreamer from CVS to catch up to the latest gstreamer bug fixes.

--- a/docs/Google_Summer_of_Code.md
+++ b/docs/Google_Summer_of_Code.md
@@ -2,7 +2,7 @@
 
 The [Google “Summer of Code” program] is available for students only. If
 we accept your project proposal, in June-July-August you work on your
-project while being payed by Google. Mid-term and end-term we evaluate
+project while being paid by Google. Mid-term and end-term we evaluate
 your work.
 
 On the technical side, it might interest you that we use GES/GStreamer

--- a/docs/Plugins.md
+++ b/docs/Plugins.md
@@ -107,26 +107,26 @@ the plugin when it is activated and a reference to them is usually kept
 inside the plugin though all its lifetime.
 
 API for UI integration allow to insert new menu items, leaving to the
-plugin the responsability to remove the inserted items when it is
+plugin the responsibility to remove the inserted items when it is
 unloaded. The same logic is applied when additional output formats are
 provided by the plugin, those must be removed from available output
 format by the plugin itself when it is deactivated.
 
 Strength points of the Jokosher approach are a well designed and
-lightweight plugin manager; the possiblity to store plugins in python
+lightweight plugin manager; the possibility to store plugins in python
 eggs that simplifies a lot the deployment of new plugins; a clean set of
 API the plugin can use to interact with the host application; the
 possibility to add new output formats; the possibility to save plugin's
 preferences without having the plugin care about serialization
 procedures.
 
-Weak points of this architecture are a limited UI integration beccause
-plugins wich uses only the API can insert menu items only under the
+Weak points of this architecture are a limited UI integration because
+plugins which uses only the API can insert menu items only under the
 “plugin” submenu; the creation of a preferences file for each plugin
 available could lead to a pollution of config files; leaving to plugins
 the duty of removing UI enhancements they inserted could lead to waste
 of memory if the plugin writer does not make a good job, a defaulf
-approach for cleaning would be preferrable.
+approach for cleaning would be preferable.
 
 ## The Trac way
 
@@ -234,7 +234,7 @@ to modules, objects and functions, since they follow the golden rule
 that “specification should make no assumption about implementation”;
 this approach leaves complete freedom to the plugin developer to
 organize its code in the way it prefers, as long the intefrace
-requirements are fullfilled; in this way duck typing gets formalized
+requirements are fulfilled; in this way duck typing gets formalized
 without adding a big overhead.
 
 `from zope.interface import Interface, implements,  providedBy`
@@ -255,9 +255,9 @@ without adding a big overhead.
 Interfaces fully supports inheritance from other interfaces (with the
 security check that children's methods conforms to ancestor's one if
 overridden), implementer of an interface hierarchy can limit the
-implentation only to a certain child interface in the lineage; the
+implementation only to a certain child interface in the lineage; the
 status of interface implementer can be attached at runtime to items that
-do not explicitely implemented the interface in their definition; as
+do not explicitly implemented the interface in their definition; as
 well the implementer status can be removed from an item at runtime
 (useful for example in containers that implement an interface by
 delegating implementation to contained objects).
@@ -334,7 +334,7 @@ file for each plugin. Eggs are similar to java's jar files, they make
 very simple the shipping and installation of new plugins since all you
 need is to drag the .egg file inside the ./plugins directory. Eggs also
 ships a standard method for exposing plugin's entry points and
-dependancies, making easy to allow cooperation/subordination among
+dependencies, making easy to allow cooperation/subordination among
 plugins.
 
 we can expect pitivi to be shipped with some default plugins available
@@ -457,7 +457,7 @@ The user:
 The plugin manager:
 
 1.  Check the plugin pool for duplicates of the plugin to be installed
-2.  Ensure the verion of the dropped plugin is newer than the current's,
+2.  Ensure the version of the dropped plugin is newer than the current's,
     otherwise prompt the user for confirmation
 3.  Remove the old plugin, preserving configuration items
 4.  Install the new plugin

--- a/docs/Praise.md
+++ b/docs/Praise.md
@@ -401,4 +401,4 @@ February 24, 2014
     Gwibber)
 -   **herrsteiner** \#Pitivi helped me to convert a video to \#ogg
     \#theora which I strangly couldn't convert on commandline without
-    loosing the audio (7:31 PM Aug 13th, 2009 from web)
+    losing the audio (7:31 PM Aug 13th, 2009 from web)

--- a/docs/QA_Scenarios.md
+++ b/docs/QA_Scenarios.md
@@ -5,7 +5,7 @@ If you see a problem in one of them, [Create a
 task](Bug_reporting.md) on Phabricator, indicating:
 
 -   which QA Scenario doesn't go through,
--   (optionnaly) the media files you used,
+-   (optionally) the media files you used,
 -   At which step it failed and what happened
 -   Which version of Pitivi was used
 
@@ -82,7 +82,7 @@ task](Bug_reporting.md) on Phabricator, indicating:
 
 1. Start with at least two clips in the timeline
 2. Click and drag the middle of one of the clips.
-   -   the trimming handles at the start and end of the clips should hilight as the mouse moves over them
+   -   the trimming handles at the start and end of the clips should highlight as the mouse moves over them
    -   the clip should move smoothly, even when vigorously scrubbed back and forth
    -   the viewer should not update during this operation **this will change when we support live previews**
    -   if thumbnails are enabled, they should appear properly even while the clip is being moved
@@ -110,7 +110,7 @@ task](Bug_reporting.md) on Phabricator, indicating:
 8. Position the playhead at the start of this clip and press play
     The volume of the clip should rise and fall with the keyframe curve.
 9. Double click the keyframe control point
-    The control point should disapear
+    The control point should disappear
 10. Double click both the start and end points
     These points should never disappear
 11. Trim the start of the clip

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -119,7 +119,7 @@ As [T2455](https://phabricator.freedesktop.org/T2455) indicates, we can
 envision two types of user experience: a semi-automatic and a
 fully-automated one. Since Pitivi is not the only application (now and
 in the future) using GES, we need to design the GES API to be flexible
-enough to accomodate the design needs of both kinds of applications.
+enough to accommodate the design needs of both kinds of applications.
 
 In both cases, the experience must be:
 

--- a/docs/attic/Audio_video.py.md
+++ b/docs/attic/Audio_video.py.md
@@ -40,7 +40,7 @@ class AVDemo(Demo):
     __usage__ = "python audio_video.py <filename>"
     __def_win_size__ = (320, 240)
 
-    # this commment allows us to include only a portion of the file
+    # this comment allows us to include only a portion of the file
     # in the tutorial for this demo
 
     def magic(self, pipeline, (videosink, audiosink), args):

--- a/docs/attic/Building_with_Windows.md
+++ b/docs/attic/Building_with_Windows.md
@@ -30,7 +30,7 @@ Install
     -   mingw32-base
     -   mingw32-gcc-g++
     -   msys-base
--   Instalation =&gt; Apply changes
+-   Installation =&gt; Apply changes
 -   Close the dialoge when complete
 
 ## CMake

--- a/docs/attic/Cross-fade.py.md
+++ b/docs/attic/Cross-fade.py.md
@@ -98,7 +98,7 @@
 
             widget = gtk.HScale(); label = gtk.Label("Crossfade")
 
-            # set appropriate atributes
+            # set appropriate attributes
             widget.set_update_policy(gtk.UPDATE_CONTINUOUS)
             widget.set_draw_value(True)
             widget.set_range(lower, upper)

--- a/docs/attic/Elements_basics.py.md
+++ b/docs/attic/Elements_basics.py.md
@@ -32,7 +32,7 @@
             gst.PAD_ALWAYS,
             gst.caps_new_any())
 
-        #sink pad (template): we recieve buffers from our sink pad
+        #sink pad (template): we receive buffers from our sink pad
         _sinktemplate = gst.PadTemplate ('sink',
             gst.PAD_SINK,
             gst.PAD_ALWAYS,

--- a/docs/attic/Enhanced_demo.py.md
+++ b/docs/attic/Enhanced_demo.py.md
@@ -37,7 +37,7 @@
         __usage__ = "python demo.py -- runs a simple test demo"
         __def_win_size__ = (320, 240)
 
-        # this commment allows us to include only a portion of the file
+        # this comment allows us to include only a portion of the file
         # in the tutorial for this demo
         # <excerpt 1>     ...
 

--- a/docs/attic/GStreamer_from_Git.md
+++ b/docs/attic/GStreamer_from_Git.md
@@ -94,7 +94,7 @@ On Fedora 12 install at least the following packages:
 </code>
 
 And to build plugins needed to use Pitivi, install these packages
-aswell:
+as well:
 
 <code>
 

--- a/docs/attic/GStreamer_using_jhbuild.md
+++ b/docs/attic/GStreamer_using_jhbuild.md
@@ -2,7 +2,7 @@
 
 JHBuild is a build tool that automates the process of building the GNOME
 software stack. It is organized somewhat like a package manager and is
-cabable of tracking dependencies between packages. JHBuild elminates a
+cabable of tracking dependencies between packages. JHBuild eliminates a
 great deal of the work of compiling GStreamer manually.
 
 **Warning: The following instructions are not supported** by the PiTiVi

--- a/docs/attic/How_To_Hack_On_PiTiVi:_Two_Case_Studies.md
+++ b/docs/attic/How_To_Hack_On_PiTiVi:_Two_Case_Studies.md
@@ -33,7 +33,7 @@ Let's create an automated of existing `videobalance` demo.
 
 ![](Color_balance_pipeline.png "Color_balance_pipeline.png")
 
-    Exerpt 1
+    Excerpt 1
 
 The trick now is to control one or more of the `videobalance` element's
 properties with a `gst.Controller`. First we create a controller, and

--- a/docs/attic/Notes_On_FCP.md
+++ b/docs/attic/Notes_On_FCP.md
@@ -20,7 +20,7 @@ timeline clips only have name and single thumbnail. single playback head
 decends from timeline ruler across entire timeline video and audio
 tracks are separated from each other in separate panes.
 
-each track (audio/video) conatins: enable/disable button, label, lock,
+each track (audio/video) contains: enable/disable button, label, lock,
 two other unidentified markings. tracks appear slightly translucent,
 with 3d beveled edges.
 
@@ -42,7 +42,7 @@ you can normalize audio clips to a peak decibel
 you can make realtime adjustments to filters applied to a clip, but
 there is also a keyframe editor.
 
-audio volume is adjustable by manipulating keyframes overlayed on top of
+audio volume is adjustable by manipulating keyframes overlaid on top of
 the waveform (rendered into the audio clip)
 
 portions of the timeline can be sent to other studio applications. when

--- a/docs/attic/PyGST_Tutorial/Combining_Audio_and_Video.md
+++ b/docs/attic/PyGST_Tutorial/Combining_Audio_and_Video.md
@@ -47,7 +47,7 @@ chain demuxers and decoders. It creates one source pad for each
 individual stream in the file. Therefore if a file contains one video
 stream and one audio stream, decodebin creates two pads: one for video,
 and one for audio. GStreamer refers to this type of behavior as
-*autoplugging* and elments which do this type of thing as
+*autoplugging* and elements which do this type of thing as
 “autopluggers”. Because decodebin can't know what's in a stream until it
 reads it, the pads are not created until the pipeline transitions into
 the ready or paused states. This is why we must link decodebin to other

--- a/docs/attic/PyGST_Tutorial/Demos/Audio_video_crossfade.py.md
+++ b/docs/attic/PyGST_Tutorial/Demos/Audio_video_crossfade.py.md
@@ -28,7 +28,7 @@
         __usage__ = "python audio_video.py <filename>"
         __def_win_size__ = (320, 240)
 
-        # this commment allows us to include only a portion of the file
+        # this comment allows us to include only a portion of the file
         # in the tutorial for this demo
 
         def onPad(self, decoder, pad, target):

--- a/docs/attic/PyGST_Tutorial/Demos/Demo.py.md
+++ b/docs/attic/PyGST_Tutorial/Demos/Demo.py.md
@@ -37,7 +37,7 @@
         __usage__ = "python demo.py -- runs a simple test demo"
         __def_win_size__ = (320, 240)
 
-        # this commment allows us to include only a portion of the file
+        # this comment allows us to include only a portion of the file
         # in the tutorial for this demo
         # <excerpt 1>     ...
 

--- a/docs/attic/PyGST_Tutorial/Elements:_basics.md
+++ b/docs/attic/PyGST_Tutorial/Elements:_basics.md
@@ -6,7 +6,7 @@ not a replacement for the GStreamer Plugin Tutorial.
 
 I will try to walk you through creating a new element that acts as a
 filter (has both a sink and source, this one wont actually do any
-filtering :)), which recieves a buffer and pushes it forward. As such it
+filtering :)), which receives a buffer and pushes it forward. As such it
 should help you avoid the pain.
 
 :   source
@@ -31,15 +31,15 @@ elements](Src-filter-sink.elemets-basics.png "source filter and sink elements")
 All new elements are derived from gst.Element or a class derived from
 gst.Element, gst.PushSrc is such an example. There are several basic
 steps common to all plugins which include registering the element with
-gstreamer, and initalising the plugin like you would anyother object.
+gstreamer, and initialising the plugin like you would any other object.
 When initialising a derivied gst.Element you must do several things,
 create the gst.Pads which describe media streams (buffers) the element
-can recieve and send, and make the pads by calling the
-gst.Element.add\_pad(gst.Pad) method. You must also overide the
+can receive and send, and make the pads by calling the
+gst.Element.add\_pad(gst.Pad) method. You must also override the
 functions specific to what you are trying to do, we are creating a
-filter (an element which both recieves and sends buffers) in this case
+filter (an element which both receives and sends buffers) in this case
 we must at minimum override the gst.Pad.set\_caps function which is used
-to negotiate which type of buffers can be recieved and the gst.Pad.chain
+to negotiate which type of buffers can be received and the gst.Pad.chain
 function which handles incoming buffers.
 
 NewElement is derived from gst.Element
@@ -63,7 +63,7 @@ gst.Element) must register it's self
             gst.PAD_ALWAYS,
             gst.caps_new_any())
 
-        #sink pad (template): we recieve buffers from our sink pad
+        #sink pad (template): we receive buffers from our sink pad
         _sinktemplate = gst.PadTemplate ('sink',
             gst.PAD_SINK,
             gst.PAD_ALWAYS,
@@ -101,8 +101,8 @@ with.
             #incoming data
             return True
 
-the pad chain function is called on sink caps (the ones recieving data),
-a buffer is recieved and pushed forward. Normally this is where we would
+the pad chain function is called on sink caps (the ones receiving data),
+a buffer is received and pushed forward. Normally this is where we would
 make changes to a buffer.
 
         def _sink_chain(self, pad, buf):

--- a/docs/attic/Simple-effect.py.md
+++ b/docs/attic/Simple-effect.py.md
@@ -67,11 +67,11 @@
             # create a place to hold our controls
             controls = gtk.VBox()
             labels = gtk.VBox()
-            # for every propety, create a control and set its attributes
+            # for every property, create a control and set its attributes
             for prop, lower, upper, default in properties:
                 widget = gtk.HScale(); label = gtk.Label(prop)
 
-                # set appropriate atributes
+                # set appropriate attributes
                 widget.set_update_policy(gtk.UPDATE_CONTINUOUS)
                 widget.set_value(default)
                 widget.set_draw_value(True)

--- a/docs/design/2007_design/2007_Advanced_UI_Mockups.md
+++ b/docs/design/2007_design/2007_Advanced_UI_Mockups.md
@@ -3,7 +3,7 @@
 ## Basic Design
 
 In basic design goal is to provide as much direct-manipulation as
-possible. In this case, properties interpolation graphs are overlayed
+possible. In this case, properties interpolation graphs are overlaid
 atop source widgets directly. The properties can be shown/hidden with
 the property selection popup at the bottom of the source. In addition,
 the interpolation mode can be set for the currently selected
@@ -14,7 +14,7 @@ keyframe.
 -   When a source in the timeline moves, the viewer needs to seek just
     before that source's in point in the timeline.
 -   When the user adjusts the in-point or out-point of a source, the
-    viewer nees to seek to the new in or out point in the source
+    viewer needs to seek to the new in or out point in the source
 -   When the user adjusts a keyframe, the viewer needs to seek to that
     point in the timeline and show the user a preview of the change
 
@@ -32,7 +32,7 @@ key-frame handles, which would not become visible until objects within
 the key-frame window are selected.
 
 All keyframed properties are initially flat lines. These lines can be
-moved up or down simply by clicking/draging.
+moved up or down simply by clicking/dragging.
 
 At this point it is not yet clear which variant would be preferable. It
 is also not yet clear how the user will add or remove key-frames.

--- a/docs/design/2007_design/2007_Advanced_UI_implementation.md
+++ b/docs/design/2007_design/2007_Advanced_UI_implementation.md
@@ -83,7 +83,7 @@ directory in the source tree:
 -   ComplexTimelineCanvas
 -   ComplexTimelineWidget
 
-# Utilites
+# Utilities
 
 The util.py file provides a number of convenience functions for working
 with goocanvas, including an easy way of creating canvas item objects,
@@ -106,7 +106,7 @@ need to know about smart group is:
 -   The smart group keeps track of its own position: Setting the x or y
     properties on a smartgroup will cause all the group's children to
     move accordingly.
--   The smart gropu keeps track of its size: If any of the group's
+-   The smart group keeps track of its size: If any of the group's
     children change size or position, the group recomputes its width and
     height properties.
 
@@ -141,7 +141,7 @@ These functions manipulate object size and position
 -   size(item)
 -   set\_size(item, size), where size is a tuple (width, height)
 
-These functions activate draging and selection management:
+These functions activate dragging and selection management:
 
 -   manage\_selection(canvas, changed\_cb)
 -   make\_selectable(canvas, item)
@@ -155,7 +155,7 @@ support for some of the convenience functions described above:
 
 ### Methods
 
--   manage\_selection(), activates internal selection managment,
+-   manage\_selection(), activates internal selection management,
     deprecates top-level function with same name
 -   make\_selectable(), activates selection management on a given
     object, deprecates top-level function with same name.
@@ -268,7 +268,7 @@ Encapsulates the concept of an important point on the timeline to which
 timestamps should be snapped during mouse operations. The class keeps
 track of all its instances in a sorted list, and uses binary search to
 implement the class method snapTime(), and snapObj, which actually
-implement magnetic edge snaping.
+implement magnetic edge snapping.
 
 ### Properties
 

--- a/docs/design/2007_design/2007_Simple_UI_Mockups.md
+++ b/docs/design/2007_design/2007_Simple_UI_Mockups.md
@@ -148,7 +148,7 @@ in red below).
 
 ### Back to timeline view
 
-The scene has shrinked back to the normal size.
+The scene has shrunk back to the normal size.
 
 ![](Deroule-editingvideo8.png "Deroule-editingvideo8.png")
 
@@ -195,7 +195,7 @@ onto an existing transition...
 ## Remove Transition
 
 To remove an existing transition, click on the cross/delete button at
-the top-right of the transition (hightlighted in red).
+the top-right of the transition (highlighted in red).
 
 ![](Deroule-removetransition1.png "Deroule-removetransition1.png")
 

--- a/docs/design/2008_design/2008_Architectural_Redesign/Design_Thoughts.md
+++ b/docs/design/2008_design/2008_Architectural_Redesign/Design_Thoughts.md
@@ -143,7 +143,7 @@ It seriously needs to be rethinked.
 
 -   Actually use ObjectFactory for producing its content
 -   Remove limitation of only one brother per object
--   Allow re-using indentical source/composition many times in a
+-   Allow re-using identical source/composition many times in a
     composition
     -   Fully synchronized (modifications to one instance are spread to
         all instances)
@@ -273,7 +273,7 @@ gnome-specific things)
 
 -   Make it generic
 -   It provides ObjectFactory objects
--   Allow acces to various kinds of source provider
+-   Allow access to various kinds of source provider
     -   Local providers (filesystem, F-Spot, Gnome media (SoC project),
         ...)
     -   Network providers (Media Asset Management)
@@ -407,7 +407,7 @@ False.
 -   interlaced support
     -   caps (differentiate raw frame/fields)
     -   Buffer Flags (TFF, Repeat)
-    -   ... and obviously support in virtually all relevent plugins
+    -   ... and obviously support in virtually all relevant plugins
 -   Perfect Profesionnal Colourspace support
     -   Various Subsampling + Chroma placement (right now we don't make
         a difference between 4:2:0 jpeg/mpeg2/dv-ntsc ... whereas they

--- a/docs/design/2008_design/2008_Architectural_Redesign/High-level_Design.md
+++ b/docs/design/2008_design/2008_Architectural_Redesign/High-level_Design.md
@@ -81,7 +81,7 @@ of three things:
 -   **Producer**(s) which are generally the contents we're using (Ex:
     Timeline, File, Network Stream, WebCam, DV VCR, ...)
 -   **Consumer**(s) which convert/process/display streams from the
-    Producers (Ex: Encoding to File, Ouputting to Screen/Speakers,
+    Producers (Ex: Encoding to File, Outputting to Screen/Speakers,
     Streaming, recording to DV VCR, ...)
 -   **Action**(s) which represent meaningful usage of the various
     producers and consumers (Ex: Record from Webcam, (Pre)View timeline,

--- a/docs/design/2008_design/2008_Architectural_Redesign/Timeline.md
+++ b/docs/design/2008_design/2008_Architectural_Redesign/Timeline.md
@@ -176,7 +176,7 @@ control](Trackobject-gnonlin-relationship.png "fig:Relationship between TrackObj
 ![Unlinking two TrackObjects coming from the same
 ObjectFactory](Timeline-object-unlinking.png "Unlinking two TrackObjects coming from the same ObjectFactory")
 
-We have a TimelineObject 'X' controling two TrackObject 'A' and 'B'
+We have a TimelineObject 'X' controlling two TrackObject 'A' and 'B'
 coming from a common ObjectFactory 'O'. This is the most common case
 when adding a Audio+Video File to the Timeline.
 
@@ -238,7 +238,7 @@ example is when we recorded Audio and Video on separate devices/files.
         ObjectFactory, we could automatically create a
         LinkedObjectFactory for the LinkedTimelineObject (XY) we just
         created
-        -   This allows infinit reuse of objects created in the
+        -   This allows infinite reuse of objects created in the
             Timeline.
 
 # Remaining issues

--- a/docs/design/2008_design/2008_Jog_and_Shuttle_controls_code_experiment.md
+++ b/docs/design/2008_design/2008_Jog_and_Shuttle_controls_code_experiment.md
@@ -107,7 +107,7 @@ As pitivi will be used by all kinds of end users, it is nice that they
 don't have to worry about codecs or transcode it first in another codec.
 
 The algorithm knows after two seeks if the codec is accurate or not. If
-it is accurate, it will show a succes icon and the correction algorithm
+it is accurate, it will show a success icon and the correction algorithm
 disables itself. If it is incorrect, it will calculate and show a
 warning sign. By clicking on the warning icon, you can optionally show
 the incorrectness. The incorrectness is the average difference between
@@ -153,7 +153,7 @@ The view supports many features, which might be interesting for pitivi:
 ### Base
 
 The view code which is independent of the toolkit is in pystreamer/view.
-It uses some ui\_\* methods which are overriden by specific toolkit
+It uses some ui\_\* methods which are overridden by specific toolkit
 methods. The events are buffered with timer threads so that the UI stays
 as responsive as possible. The timer thread will not send seek events
 for every user event, but rather keep track and only request a next seek

--- a/docs/design/2008_design/2008_Plugin_Interface_development.md
+++ b/docs/design/2008_design/2008_Plugin_Interface_development.md
@@ -86,7 +86,7 @@ would be
 
 At the moment plugin.settings must be a
 pitivi.pluginsettings.SettingsStore object, this object can then create
-xml data to store and retrive the settings as needed.
+xml data to store and retrieve the settings as needed.
 
 a further example for the entire settings store is:
 
@@ -123,7 +123,7 @@ configuration dialog.
 
 The current implimentation is a mix-in object that replaces the
 configure() method with our own gui-builder code (plugin authors that
-need more flexability can create their own configure() method)
+need more flexibility can create their own configure() method)
 
 the gui-builder code simply parses the current settings object and is
 able to build a gui from the fields provided, for example it will
@@ -136,7 +136,7 @@ with a widget argument, for example:
 
 this code will provide an input widget where the characters are starred
 out which is appropriate for a password field. plugins can even provide
-their own widgets by subclassing FieldWidget but this is absolutly not
+their own widgets by subclassing FieldWidget but this is absolutely not
 nessasserry
 
 #### custom configuration widget example
@@ -248,7 +248,7 @@ The above example produces the following image
 
         # this is another floating point setting but we use a different widget
         # to draw it, the scaleField widget will allow people to configure the
-        # setting by draging a handlebar around
+        # setting by dragging a handlebar around
         arange = FloatField('push this widget around', default=10.0, priority=500,
                             max_value=100.0, min_value=0.0,
                             widget=pluginsettings.scaleField_widget)
@@ -258,7 +258,7 @@ The above example produces the following image
                                widget=pluginsettings.scaleField_widget)
 
         # this is a boolean value, it will store True/False values, we set draw_label
-        # to false because the checkbutton thats used to draw this setting already
+        # to false because the checkbutton that's used to draw this setting already
         # contains a label inside it
         truth = BooleanField('this is a truth value', default=True, draw_label=False)
 
@@ -284,7 +284,7 @@ The above example produces the following image
                                    widget=pluginsettings.scaleField_widget)
 
 
-    # this is our main plugin class thats called by pitivi, we subclass it from
+    # this is our main plugin class that's called by pitivi, we subclass it from
     # ConfigureBuilder so that we can have a settings dialog built for us
     class Configure_Test(pluginsettings.ConfigureBuilder):
 
@@ -312,7 +312,7 @@ The above example produces the following image
             # load our saved settings
             self.manager.loadSettings(self)
 
-            # connect up the 'enabled changed' signal, its a signal thats emitted
+            # connect up the 'enabled changed' signal, its a signal that's emitted
             # when the plugin.enabled state is changed somehow, obviously our
             # plugin has to take note of that and disable/enable its functionality
             # accordingly

--- a/docs/design/2008_design/2008_UI_Design.md
+++ b/docs/design/2008_design/2008_UI_Design.md
@@ -60,7 +60,7 @@ Frequent Tasks
 -   finding a specific time in the timeline
 -   shifting a clip's start position
 -   triming a clip's in or out position
--   spliting a clip into multiple pieces
+-   splitting a clip into multiple pieces
 -   previewing the project
 -   adjusting audio volume or video alpha
 -   moving sources between layers
@@ -577,7 +577,7 @@ properties of the currently selected timeline object(s) (for example,
 audio balance, or image color correction). The type of controls
 presented are determined by the current selection:
 
--   accessable at all times by clicking on its tab
+-   accessible at all times by clicking on its tab
 -   default interface which simply presents a control for every
     available property should work in the majority of cases
     -   time-varying properties are presented on an interpolation graph

--- a/docs/design/Proxy_editing_requirements.md
+++ b/docs/design/Proxy_editing_requirements.md
@@ -27,7 +27,7 @@ As [T2455](https://phabricator.freedesktop.org/T2455) indicates, we can
 envision two types of user experience: a semi-automatic and a
 fully-automated one. Since Pitivi is not the only application (now and
 in the future) using GES, we need to design the GES API to be flexible
-enough to accomodate the design needs of both kinds of applications.
+enough to accommodate the design needs of both kinds of applications.
 
 In both cases, the experience must be:
 

--- a/docs/design/timeline.txt
+++ b/docs/design/timeline.txt
@@ -190,7 +190,7 @@ Timeline view design document (c) 2005 Edward Hervey
 	     [ Layers of sources				]
 
     * Properties:
-      _ Global Simple Effect(s) (Optionnal)
+      _ Global Simple Effect(s) (Optional)
       _ Simple Effect(s)
       _ Complex Effect(s)
       _ Transition(s)

--- a/docs/ges_port.notes
+++ b/docs/ges_port.notes
@@ -28,7 +28,7 @@ GES:
                 *Done:
 
         -> Implement groups
-                > Beteen 7 and 10 days
+                > Between 7 and 10 days
 
         -> Add the timeline_edition API:
             => 4 more days:
@@ -57,7 +57,7 @@ Pitivi:
 
     Critical
     ========
-        -> Make Seeker more powerfull, and rely only on it for all the:
+        -> Make Seeker more powerful, and rely only on it for all the:
            seeking:
             => 2 days DONE:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -53,7 +53,7 @@ on the website (includes a “Why contribute to Pitivi?” section).
 
 -   [Goals](Goals.md) (mission statement, vision)
 -   [Project history](Project_history.md) - rumors of our death
-    have been greatly exagerated... :)
+    have been greatly exaggerated... :)
 -   [Current events](Current_events.md) - releases, meetings,
     talks ... See also the [planet](http://www.pitivi.org/planet) for
     news about the project.

--- a/docs/pylint.rc
+++ b/docs/pylint.rc
@@ -1,6 +1,6 @@
 # lint Python modules using external checkers.
 #
-# This is the main checker controling the other ones and the reports
+# This is the main checker controlling the other ones and the reports
 # generation. It is itself both a raw checker and an astng checker in order
 # to:
 # * handle message activation / deactivation at the module level
@@ -130,7 +130,7 @@ int-import-graph=
 # checks for :
 # * methods without self as first argument
 # * overridden methods signature
-# * access only to existant members via self
+# * access only to existent members via self
 # * attributes not defined in the __init__ method
 # * supported interfaces implementation
 # * unreachable code

--- a/docs/releases/0.10.2.md
+++ b/docs/releases/0.10.2.md
@@ -40,7 +40,7 @@ series of the PiTiVi opensource video editor.
 -   [352400](http://bugzilla.gnome.org/show_bug.cgi?id=352400) :
     \[importing\] Allow importing (sub)folders
 -   [353861](http://bugzilla.gnome.org/show_bug.cgi?id=353861) : Don't
-    close filechooser dialog box immediatly
+    close filechooser dialog box immediately
 -   [377117](http://bugzilla.gnome.org/show_bug.cgi?id=377117) : pitivi
     won't start
 -   [378865](http://bugzilla.gnome.org/show_bug.cgi?id=378865) : Windows

--- a/docs/releases/0.10.3.md
+++ b/docs/releases/0.10.3.md
@@ -48,7 +48,7 @@ series of the PiTiVi opensource video editor.
     \[Rendering dialog\] Gettext issue, and button not disabled when
     rendering
 -   [432644](http://bugzilla.gnome.org/show_bug.cgi?id=432644) :
-    \[Advanced Timeline\] Disable alltogether until it works
+    \[Advanced Timeline\] Disable altogether until it works
 -   [432655](http://bugzilla.gnome.org/show_bug.cgi?id=432655) :
     \[Importing Files\] Blocking and progress indication
 -   [432656](http://bugzilla.gnome.org/show_bug.cgi?id=432656) : Source

--- a/docs/releases/0.11.3.md
+++ b/docs/releases/0.11.3.md
@@ -32,7 +32,7 @@ or war caused by this unstable series.
 -   [560150](http://bugzilla.gnome.org/show_bug.cgi?id=560150) : Error
     when clicking on nothing
 -   [560330](http://bugzilla.gnome.org/show_bug.cgi?id=560330) : Pitivi
-    dont import any video (python trouble)
+    don't import any video (python trouble)
 -   [560844](http://bugzilla.gnome.org/show_bug.cgi?id=560844) :
     timecode is incorrectly displayed
 -   [560850](http://bugzilla.gnome.org/show_bug.cgi?id=560850) : font

--- a/docs/releases/0.13.2.md
+++ b/docs/releases/0.13.2.md
@@ -151,9 +151,9 @@ repository](https://launchpad.net/~gstreamer-developers/+archive/ppa).
 -   [584415](http://bugzilla.gnome.org/show_bug.cgi?id=584415) : Cairo -
     &gt; cairo
 -   [584416](http://bugzilla.gnome.org/show_bug.cgi?id=584416) :
-    Ambigous string
+    Ambiguous string
 -   [586184](http://bugzilla.gnome.org/show_bug.cgi?id=586184) :
-    formatter cant find all streams on project load
+    formatter can't find all streams on project load
 -   [587327](http://bugzilla.gnome.org/show_bug.cgi?id=587327) : write
     all temp files into one folder in /tmp
 -   [587378](http://bugzilla.gnome.org/show_bug.cgi?id=587378) : Ctrl +

--- a/docs/releases/0.15.md
+++ b/docs/releases/0.15.md
@@ -23,7 +23,7 @@ installed.
 -   Integrated offline user manual
 -   Cleaner advanced codec settings dialog
 -   Improved video thumbnailing performance
--   “Soft depedencies” manager to warn the user of features requiring
+-   “Soft dependencies” manager to warn the user of features requiring
     additional packages
 -   Port to gtkbuilder
 -   Respect GNOME's button icons setting

--- a/intltool-update.in
+++ b/intltool-update.in
@@ -291,7 +291,7 @@ sub TextFile_DetermineEncoding ($)
 	}
 	elsif ($filetype =~ /^XML/)
 	{
-	    $gettext_code="UTF-8"; # We asume that .glade and other .xml files are UTF-8
+	    $gettext_code="UTF-8"; # We assume that .glade and other .xml files are UTF-8
 	}
     }
 

--- a/pitivi/utils/loggable.py
+++ b/pitivi/utils/loggable.py
@@ -907,7 +907,7 @@ def outputToFiles(stdout=None, stderr=None):
         info('log', "Received SIGHUP, reopening logs")
         reopenOutputFiles()
         if _old_hup_handler:
-            info('log', "Calling old SIGHUP hander")
+            info('log', "Calling old SIGHUP handler")
             _old_hup_handler(signum, frame)
 
     debug('log', 'installing SIGHUP handler')

--- a/pitivi/utils/pipeline.py
+++ b/pitivi/utils/pipeline.py
@@ -618,7 +618,7 @@ class Pipeline(GES.Pipeline, SimplePipeline):
 
         if message.type == Gst.MessageType.ASYNC_DONE and\
                 self._commit_wanted:
-            self.debug("Commiting now that ASYNC is DONE")
+            self.debug("Committing now that ASYNC is DONE")
             self._addWaitingForAsyncDoneTimeout()
             self.props.timeline.commit()
             self._commit_wanted = False
@@ -638,13 +638,13 @@ class Pipeline(GES.Pipeline, SimplePipeline):
         else:
             self._addWaitingForAsyncDoneTimeout()
             self.props.timeline.commit()
-            self.debug("Commiting right now")
+            self.debug("Committing right now")
             self._was_empty = is_empty
 
     def setState(self, state):
         SimplePipeline.setState(self, state)
         if state >= Gst.State.PAUSED and self.props.timeline.is_empty():
-            self.debug("No ASYNC_DONE will be emited on empty timelines")
+            self.debug("No ASYNC_DONE will be emitted on empty timelines")
             self._was_empty = True
             self._removeWaitingForAsyncDoneTimeout()
 

--- a/pitivi/utils/pipeline.py
+++ b/pitivi/utils/pipeline.py
@@ -613,7 +613,7 @@ class Pipeline(GES.Pipeline, SimplePipeline):
 
     def _busMessageCb(self, bus, message):
         if message.type == Gst.MessageType.ASYNC_DONE:
-            self.commiting = False
+            self.committing = False
             self.app.gui.timeline_ui.timeline.update_visible_overlays()
 
         if message.type == Gst.MessageType.ASYNC_DONE and\

--- a/pitivi/utils/ripple_update_group.py
+++ b/pitivi/utils/ripple_update_group.py
@@ -47,20 +47,20 @@ class RippleUpdateGroup(object):
         - zero or more user-specified arguments, passed to the
           update_function.
 
-    An edge between two verticies represents a sequence of operations. If an
+    An edge between two vertices represents a sequence of operations. If an
     edge exists from object A to object B, then whenever A is perfomred, B
     should be performed too -- unless it has already been visited as part of
     this update cycle.
 
     In addition to a a pair of objects, each edge also has the following
-    assoicated with it:
+    associated with it:
 
         - a predicate function. called during an update cycle when this edge
           is reached, and before any other processing is done. If this
           function returns false, it will be as if this edge otherwise did not
           exist.
 
-        - a function to be called whenver the edge is visited during an update
+        - a function to be called whenever the edge is visited during an update
           cycle. this function will not be called if the condition function
           returns False.
 
@@ -77,7 +77,7 @@ class RippleUpdateGroup(object):
 
     def addVertex(self, widget, signal=None, update_func=None,
                   update_func_args=()):
-        """Adds a widget to the list of vertexes.
+        """Adds a widget to the list of vertices.
 
         Args:
             widget (Gtk.Widget): The vertex to be added.
@@ -106,7 +106,7 @@ class RippleUpdateGroup(object):
         self.arcs[widget_a].append((widget_b, predicate, edge_func))
 
     def addBiEdge(self, widget_a, widget_b, predicate=None, edge_func=None):
-        """Adds a bidirectional edge between the specified vertexes.
+        """Adds a bidirectional edge between the specified vertices.
 
         See `addEdge`.
         """

--- a/pitivi/utils/system.py
+++ b/pitivi/utils/system.py
@@ -69,7 +69,7 @@ class System(GObject.Object, Loggable):
 
 
 class FreedesktopOrgSystem(System):
-    """Provides messaging capabilites for desktops that implement fd.o specs."""
+    """Provides messaging capabilities for desktops that implement fd.o specs."""
 
     def __init__(self):
         System.__init__(self)

--- a/pitivi/utils/validate.py
+++ b/pitivi/utils/validate.py
@@ -133,7 +133,7 @@ def stop(scenario, action):
 
         if project:
             project.setModificationState(False)
-            GstValidate.print_action(action, "Force quiting, ignoring any"
+            GstValidate.print_action(action, "Force quitting, ignoring any"
 
                                      " changes in the project\n")
         timeline.ui.app.shutdown()
@@ -290,7 +290,7 @@ def editContainer(scenario, action):
     if container is None:
         for layer in timeline.get_layers():
             for clip in layer.get_clips():
-                Gst.info("Exisiting clip: %s" % clip.get_name())
+                Gst.info("Existing clip: %s" % clip.get_name())
 
         scenario.report_simple(GLib.quark_from_string("scenario::execution-error"),
                                "Could not find container: %s"

--- a/pitivi/viewer/move_scale_overlay.py
+++ b/pitivi/viewer/move_scale_overlay.py
@@ -408,7 +408,7 @@ class MoveScaleOverlay(Overlay):
         self.handles[(Edge.bottom, Edge.left)].position = numpy.array([0, size[1]])
         self.handles[(Edge.bottom, Edge.right)].position = numpy.array([size[0], size[1]])
         self.handles[(Edge.top, Edge.right)].position = numpy.array([size[0], 0])
-        self.__update_egdes_from_corners()
+        self.__update_edges_from_corners()
 
     def __set_position(self, position):
         for handle in self.handles.values():
@@ -426,7 +426,7 @@ class MoveScaleOverlay(Overlay):
         for handle in self.handles.values():
             handle.restrict_radius_to_size(smaller_size)
 
-    def __update_egdes_from_corners(self):
+    def __update_edges_from_corners(self):
         half_w = numpy.array([self.__get_width() * 0.5, 0])
         half_h = numpy.array([0, self.__get_height() * 0.5])
 
@@ -494,7 +494,7 @@ class MoveScaleOverlay(Overlay):
         if self.__clicked_handle:
             # Resize Box / Use Handle
             self.__clicked_handle.on_drag(click_to_cursor)
-            self.__update_egdes_from_corners()
+            self.__update_edges_from_corners()
 
             # We only need to change translation coordinates in the source for resizing
             # when handle does not return NULL for get_source_position

--- a/pitivi/viewer/viewer.py
+++ b/pitivi/viewer/viewer.py
@@ -498,16 +498,16 @@ class ViewerWidget(Gtk.AspectFrame, Loggable):
         self.set_property("ratio", float(ratio))
 
     def do_get_preferred_width(self):
-        mininum, unused_natural = Gtk.AspectFrame.do_get_preferred_width(self)
+        minimum, unused_natural = Gtk.AspectFrame.do_get_preferred_width(self)
         # Do not let a chance for Gtk to choose video natural size
         # as we want to have full control
-        return mininum, mininum + 1
+        return minimum, minimum + 1
 
     def do_get_preferred_height(self):
-        mininum, unused_natural = Gtk.AspectFrame.do_get_preferred_height(self)
+        minimum, unused_natural = Gtk.AspectFrame.do_get_preferred_height(self)
         # Do not let a chance for Gtk to choose video natural size
         # as we want to have full control
-        return mininum, mininum + 1
+        return minimum, minimum + 1
 
 
 class PlayPauseButton(Gtk.Button, Loggable):

--- a/tests/test_clipproperties.py
+++ b/tests/test_clipproperties.py
@@ -83,7 +83,7 @@ class TransformationPropertiesTest(BaseTestTimeline):
         Tests that the transformation properties spin buttons display
         the correct values of the source properties.
         """
-        # Create tranformation box
+        # Create transformation box
         transformation_box = self.setup_transformation_box()
         timeline = transformation_box.app.gui.timeline_ui.timeline
         spin_buttons = transformation_box.spin_buttons
@@ -115,7 +115,7 @@ class TransformationPropertiesTest(BaseTestTimeline):
         Tests that changes in spin buttons values are reflected in source
         properties.
         """
-        # Create tranformation box
+        # Create transformation box
         transformation_box = self.setup_transformation_box()
         timeline = transformation_box.app.gui.timeline_ui.timeline
         spin_buttons = transformation_box.spin_buttons
@@ -152,7 +152,7 @@ class TransformationPropertiesTest(BaseTestTimeline):
         Check that spin buttons update correctly when changing the selected
         clip.
         """
-        # Create tranformation box
+        # Create transformation box
         transformation_box = self.setup_transformation_box()
         timeline = transformation_box.app.gui.timeline_ui.timeline
         spin_buttons = transformation_box.spin_buttons

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -87,7 +87,7 @@ class TestProjectManager(TestCase):
 
     def testLoadProjectClosesCurrent(self):
         """
-        Check that new-project-failed is emited if we can't close the current
+        Check that new-project-failed is emitted if we can't close the current
         project instance.
         """
         state = {"tried-close": False}
@@ -610,7 +610,7 @@ class TestExportSettings(TestCase):
         self._testMasterAttribute('aencoder', dependant_attr='acodecsettings')
 
     def _testMasterAttribute(self, attr, dependant_attr):
-        """Test changing the specified attr has effect on its dependant attr."""
+        """Test changing the specified attr has effect on its dependent attr."""
         project = common.create_project()
 
         attr_value1 = "%s_value1" % attr


### PR DESCRIPTION
Documentation and source comment typos found with `codespell -q 3 -w --skip="./help,./po,*.svg" -I ../pitivi--whitelist.txt` 
where whitelist contained:
```
iff
que
ressources
seeked
superceded
unselect
```