### PR TITLE
[FIX] Paste copied clip(s) multiple times

### DIFF
--- a/pitivi/timeline/timeline.py
+++ b/pitivi/timeline/timeline.py
@@ -1739,12 +1739,11 @@ class TimelineContainer(Gtk.Grid, Zoomable, Loggable):
             return
 
         with self.app.action_log.started("paste",
-                                         finalizing_action=CommitTimelineFinalizingAction(self._project.pipeline),
-                                         toplevel=True):
-            save = self.__copiedGroup.copy(True)
+                    finalizing_action=CommitTimelineFinalizingAction(self._project.pipeline),
+                    toplevel=True):
             position = self._project.pipeline.getPosition()
-            self.__copiedGroup.paste(position)
-            self.__copiedGroup = save
+            copiedGroupShallowCopy = self.__copiedGroup.paste(position)
+            self.__copiedGroup = copiedGroupShallowCopy.copy(True)
 
     def _alignSelectedCb(self, unused_action, unused_parameter):
         if not self.ges_timeline:

--- a/tests/test_timeline_timeline.py
+++ b/tests/test_timeline_timeline.py
@@ -475,6 +475,7 @@ class TestCopyPaste(BaseTestTimeline):
         clips = layer.get_clips()
         self.assertEqual(len(clips), 2)
 
+        # Pasting clips for the first time.
         timeline_container.paste_action.emit("activate", None)
 
         n_clips = layer.get_clips()
@@ -484,6 +485,19 @@ class TestCopyPaste(BaseTestTimeline):
         self.assertEqual(len(copied_clips), 2)
         self.assertEqual(copied_clips[0].props.start, position)
         self.assertEqual(copied_clips[1].props.start, position + 10)
+
+        # Pasting same clips second time.
+        position = 40
+        project.pipeline.getPosition = mock.Mock(return_value=position)
+        timeline_container.paste_action.emit("activate", None)
+
+        n_clips = layer.get_clips()
+        self.assertEqual(len(n_clips), 6)
+
+        copied_clips = [clip for clip in n_clips if clip not in clips]
+        self.assertEqual(len(copied_clips), 4)
+        self.assertEqual(copied_clips[2].props.start, position)
+        self.assertEqual(copied_clips[3].props.start, position + 10)
 
 
 class TestEditing(BaseTestTimeline):


### PR DESCRIPTION
Fix for T7639 - Cannot paste copied clip multiple times

The commit contains description on why the previous logic was failing.

Added a test case as well.