### PR TITLE
misc. global typo  fixes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,8 +55,8 @@ test-results:
         - export TMPIMAGENAME="tmp-pitivi-${BRANCH}"
         - echo ${TMPIMAGENAME}
 
-        # Not using a Dockerfile because we need the container to be priviledged to run flatpak inside of it
-        # and it is not possible to use a priviledged `docker build`.
+        # Not using a Dockerfile because we need the container to be privileged to run flatpak inside of it
+        # and it is not possible to use a privileged `docker build`.
         - export ALLURE_VERSION=2.7.0
         - export ALLURE_DL_URL="https://bintray.com/qameta/generic/download_file?file_path=io%2Fqameta%2Fallure%2Fallure%2F2.7.0%2Fallure-${ALLURE_VERSION}.zip"
         - export INSTALL_ALLURE="yum install java wget -y && wget ${ALLURE_DL_URL} -O allure.zip && unzip allure.zip && mv allure-${ALLURE_VERSION} /opt/allure && chmod +x /opt/allure/bin/allure && rm allure.zip"

--- a/build/flatpak/pitivi-flatpak
+++ b/build/flatpak/pitivi-flatpak
@@ -413,7 +413,7 @@ class PitiviFlatpak:  # pylint: disable=too-many-instance-attributes
                 if verbose:
                     Console.message("\n%sYou need to install %s >= %s"
                                     " to be able to use the '%s' script.\n\n"
-                                    "You can find some informations about"
+                                    "You can find some information about"
                                     " how to install it for your distribution at:\n"
                                     "    * http://flatpak.org/%s\n", Colors.FAIL,
                                     app, required_version, sys.argv[0], Colors.ENDC)

--- a/docs/Feroze_gsoc.md
+++ b/docs/Feroze_gsoc.md
@@ -26,7 +26,7 @@ following areas:
 
 Most users want the output formatted for a specific device or service –
 YouTube, iPod, iPhone, DVD, mobile, etc. Presently, the user would have
-to manually specify the codecs, containter and codec settings like
+to manually specify the codecs, container and codec settings like
 resolution, frame rate,etc. He would have to either be familiar with the
 codecs or would have to google it up.
 

--- a/docs/Google_SoC_2007_-_Simple_Timeline.md
+++ b/docs/Google_SoC_2007_-_Simple_Timeline.md
@@ -136,7 +136,7 @@ advanced timeline, but has run afoul of some gstreamer bugs.
 
 I'm considering replacing the slider with a gtk.ScaleButton, since that
 would allow the source widget to shrink down even more while allowing
-the slider to grow to a more managable size. I'm also thinking about a
+the slider to grow to a more manageable size. I'm also thinking about a
 custom widget for seeking that would eventually replace the simple
 gtk.HScales we've been using. It feature a much slimmer cursor, would
 support zooming, display a timescale, provide fancy navigation input

--- a/docs/HACKING.md
+++ b/docs/HACKING.md
@@ -19,7 +19,7 @@ Make sure to use the right git repository:
 > NOTE: This way of setting the development environment is sensibly more complex
 > but also more flexible than the one for newcomers. If you are a  beginner
 > or if you usually use [gnome-builder](https://wiki.gnome.org/Apps/Builder)
-> as your main IDE, follow, as previously adviced, the
+> as your main IDE, follow, as previously advised, the
 > [GNOME Newcomers guide](https://wiki.gnome.org/Newcomers/)
 
 The official way of getting your environment up and running is by using

--- a/docs/Plugins.md
+++ b/docs/Plugins.md
@@ -584,7 +584,7 @@ Class IRecordingDevice(Interface):
 `   def stop():`\
 `   `“`"`”` Stop recording `“`"`”\
 `   def isRecording():`\
-`   `“`"`”` Returns true if the defice is currently recording `“`"`”
+`   `“`"`”` Returns true if the device is currently recording `“`"`”
 
 ## Effects/Transitions
 

--- a/docs/Praise.md
+++ b/docs/Praise.md
@@ -123,7 +123,7 @@ Reddit](https://www.reddit.com/r/linux/comments/4v0swv/pitivi_096_a_great_releas
 > became software programmer), and used Final Cut Pro. I have always
 > been a Linux user though, and have meddled with everything that exist
 > every single year. Cinelerra was always the fall-back that would never
-> really let me down because it was frank about its crashers and they
+> really let me down because it was frank about its crashes and they
 > were possible to navigate around.
 >
 > In later years, I did find Pitivi to be a possible replacement for
@@ -400,5 +400,5 @@ February 24, 2014
     \#Pitivi was perfect for the job. (9:44 AM Aug 14th, 2009 from
     Gwibber)
 -   **herrsteiner** \#Pitivi helped me to convert a video to \#ogg
-    \#theora which I strangly couldn't convert on commandline without
+    \#theora which I strangely couldn't convert on commandline without
     losing the audio (7:31 PM Aug 13th, 2009 from web)

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -43,7 +43,7 @@ See [Current events](Current_events.md) for past items.
     See for example [audio
     normalization](https://gitlab.gnome.org/GNOME/pitivi/issues/638)
     or the [autoaligner
-    ressurection](https://gitlab.gnome.org/GNOME/pitivi/issues/1345).
+    resurrection](https://gitlab.gnome.org/GNOME/pitivi/issues/1345).
 
 ## Motion ramping, time stretching
 

--- a/docs/attic/Building_with_Windows.md
+++ b/docs/attic/Building_with_Windows.md
@@ -151,7 +151,7 @@ manually.
 
 ### Adding GStreamer tools to the PATH
 
-You propably want to use ges-launch-1.0.exe and friends in the shell. To
+You probably want to use ges-launch-1.0.exe and friends in the shell. To
 do this, add the dist folder to the PATH.
 
 In your bash profle:

--- a/docs/attic/Project_loading_and_saving.md
+++ b/docs/attic/Project_loading_and_saving.md
@@ -110,7 +110,7 @@ first.
         unchanged
 10. Modified Project State, New Project Command
     1.  Close Project confirmation dialog displayed, presenting choices
-        of “Save”, “Dont' Save”, and “Cancel”
+        of “Save”, “Don't Save”, and “Cancel”
         1.  Cancel: a new project is not created, and the old project is
             not saved
         2.  Don't Save: the new project will replace the current, and it

--- a/docs/attic/PyGST_Tutorial/Elements:_basics.md
+++ b/docs/attic/PyGST_Tutorial/Elements:_basics.md
@@ -5,7 +5,7 @@ plugin, and explain what each part does succinctly. This is a jumpstart,
 not a replacement for the GStreamer Plugin Tutorial.
 
 I will try to walk you through creating a new element that acts as a
-filter (has both a sink and source, this one wont actually do any
+filter (has both a sink and source, this one won't actually do any
 filtering :)), which receives a buffer and pushes it forward. As such it
 should help you avoid the pain.
 

--- a/docs/attic/PyGST_Tutorial/Introduction.md
+++ b/docs/attic/PyGST_Tutorial/Introduction.md
@@ -46,4 +46,4 @@ inconvenience.
 ## A Word of Caution
 
 This information is for educational purposes only. It is provided free
-of chage, use at your own risk.
+of charge, use at your own risk.

--- a/docs/design/2007_design/2007_Advanced_UI_implementation.md
+++ b/docs/design/2007_design/2007_Advanced_UI_implementation.md
@@ -205,7 +205,7 @@ current UI selection. This is kept strictly separate from Dragable, as
 there is a use case for selectable objects which cannot be moved by the
 user, as well as a use case for dragable objects which should never
 become part of the current selection. Objects are selected with
-Select(), and deslected with Deselect(). Objects are notified of their
+Select(), and deselected with Deselect(). Objects are notified of their
 selection status through the selected() and deselected() method calls.
 
 Being part of the selection implies that the object represents data that

--- a/docs/design/2008_design/2008_UI_Design.md
+++ b/docs/design/2008_design/2008_UI_Design.md
@@ -59,7 +59,7 @@ Frequent Tasks
 
 -   finding a specific time in the timeline
 -   shifting a clip's start position
--   triming a clip's in or out position
+-   trimming a clip's in or out position
 -   splitting a clip into multiple pieces
 -   previewing the project
 -   adjusting audio volume or video alpha
@@ -110,7 +110,7 @@ Timeline, Clip Library, and Clip Editor, and Effect Library can be
 detached from the main window by clicking a special “detach” button.
 These windows appear as normal top-level windows. When the user closes
 one of these windows, the component returns to its default location. In
-addition, the clip editor and viwer can be “expanded” so that they
+addition, the clip editor and viewer can be “expanded” so that they
 completely fill their parent windows.
 
 ## Keyboard
@@ -403,7 +403,7 @@ is initially collapsed.
 Trimming a clip is always possible by clicking/dragging on source
 trimming handles. By default, the in or out point of a clip should be
 edge-snapped (so that it is easy to put the clip back the way it was).
-The UI should constrain the the settingof in/out point so that sources
+The UI should constrain the setting of in/out point so that sources
 can't be stretched beyond maximum native duration. **clicking and
 dragging a trimming handle should not change the current selection**
 
@@ -693,7 +693,7 @@ Specify sets of pictures which will be displayed in sequence:
 
 Other Ideas:
 
--   backround / cell paradigm -- user chooses a back drop, and can
+-   background / cell paradigm -- user chooses a back drop, and can
     composite multiple layers of translucent/transparent cells
 
 ## Motion Transform Editor
@@ -718,11 +718,11 @@ NEEDS WORK
 
 Chroma key
 
--   set thresholds, choos key color (eye-dropper?)
+-   set thresholds, choose key color (eye-dropper?)
 
 Blue/Green/Red screen
 
--   set thesholds
+-   set thresholds
 
 Should thresholds and key-color be time varying? Definitely need at
 least a local preview. Using the viewer would be better.
@@ -810,8 +810,8 @@ accept/deny their inclusion.
 -   hotkey configuration
 -   direct manipulation
 -   autosave
--   default location to use when optening a file or importing clips
-    (last forlder, arbitrary location)
--   color values for the timeline ruler and the backround of clips
+-   default location to use when opening a file or importing clips
+    (last folder, arbitrary location)
+-   color values for the timeline ruler and the background of clips
 -   whether edge snapping is enabled by default
 -   the size of deadband to use for edge snapping

--- a/docs/release.md
+++ b/docs/release.md
@@ -4,7 +4,7 @@ Ideally these instructions are in line with the [GNOME releasing process](https:
 
 We make two types of releases:
 - regular releases, when we have new features or improvements, and
-- "smaller" bug-fix releases, when a regular relese needs patching.
+- "smaller" bug-fix releases, when a regular release needs patching.
 
 The regular releases have the version number X.YY, and the bug-fix
 releases have the version number X.YY.Z, where Z is hopefully a relatively small

--- a/help/C/welcomedialog.page
+++ b/help/C/welcomedialog.page
@@ -29,7 +29,7 @@
       <p><gui>Browse projects...</gui> opens file chooser in the last used directory.</p>
     </item>
     <item>
-      <p><gui>Help</gui> opens the user documenation on the index page.</p>
+      <p><gui>Help</gui> opens the user documentation on the index page.</p>
     </item>
     <item>
       <p><gui>Keyboard shortcuts</gui> opens the user documentation on the Keyboard shortcuts and cheatsheet page.</p>

--- a/pitivi/timeline/elements.py
+++ b/pitivi/timeline/elements.py
@@ -1197,7 +1197,7 @@ class Clip(Gtk.EventBox, Zoomable, Loggable):
         if self.__force_position_update or \
                 x != self._current_x or \
                 y != self._current_y or \
-                width != self._curent_width or \
+                width != self._current_width or \
                 parent_height != self._current_parent_height or \
                 layer != self._current_parent:
 
@@ -1211,7 +1211,7 @@ class Clip(Gtk.EventBox, Zoomable, Loggable):
             self.__force_position_update = False
             self._current_x = x
             self._current_y = y
-            self._curent_width = width
+            self._current_width = width
             self._current_parent_height = parent_height
             self._current_parent = layer
 

--- a/pitivi/timeline/previewers.py
+++ b/pitivi/timeline/previewers.py
@@ -78,7 +78,7 @@ GlobalSettings.addConfigOption("previewers_max_cpu",
 
 
 class PreviewerBin(Gst.Bin, Loggable):
-    """Baseclass for elements gathering datas to create previews."""
+    """Baseclass for elements gathering data to create previews."""
     def __init__(self, bin_desc):
         Gst.Bin.__init__(self)
         Loggable.__init__(self)

--- a/pitivi/utils/loggable.py
+++ b/pitivi/utils/loggable.py
@@ -245,7 +245,7 @@ class ProgressBar:
         self.term = term
         if not (self.term.CLEAR_EOL and self.term.UP and self.term.BOL):
             raise ValueError("Terminal isn't capable enough -- you "
-                             "should use a simpler progress dispaly.")
+                             "should use a simpler progress display.")
         self.width = self.term.COLS or 75
         self.bar = term.render(self.BAR)
         self.header = self.term.render(self.HEADER % header.center(self.width))

--- a/pitivi/utils/ripple_update_group.py
+++ b/pitivi/utils/ripple_update_group.py
@@ -48,7 +48,7 @@ class RippleUpdateGroup(object):
           update_function.
 
     An edge between two vertices represents a sequence of operations. If an
-    edge exists from object A to object B, then whenever A is perfomred, B
+    edge exists from object A to object B, then whenever A is performed, B
     should be performed too -- unless it has already been visited as part of
     this update cycle.
 


### PR DESCRIPTION
Found with `codespell -q 3 -I ../pitivi--whitelist.txt --skip="*.po,*.svg"`