### PR TITLE
Add portable AppImage packaging + CI/release workflows

### DIFF
--- a/.github/workflows/_appimage-build.yml
+++ b/.github/workflows/_appimage-build.yml
@@ -1,0 +1,122 @@
+# Reusable workflow: build a single (arch, variant) AppImage and smoke-test
+# it. Called by ci-appimage.yml (on PR/push) and release-appimage.yml (on
+# tag). Outputs the artifact name so the caller can reference it.
+name: Build & smoke-test AppImage
+
+on:
+  workflow_call:
+    inputs:
+      arch:
+        type: string
+        required: true
+        description: x86_64 or aarch64
+      variant:
+        type: string
+        required: true
+        description: full or lean
+      retention-days:
+        type: number
+        required: false
+        default: 14
+        description: How long to keep the artifact (CI runs).
+    outputs:
+      artifact-name:
+        description: Name of the uploaded artifact (also the AppImage filename).
+        value: ${{ jobs.build.outputs.artifact-name }}
+
+jobs:
+  build:
+    name: ${{ inputs.arch }} / ${{ inputs.variant }}
+    # ubuntu-22.04-arm is the free aarch64 runner GitHub made GA in
+    # April 2025 for public repos.
+    runs-on: ${{ inputs.arch == 'aarch64' && 'ubuntu-22.04-arm' || 'ubuntu-latest' }}
+    outputs:
+      artifact-name: ${{ steps.build.outputs.artifact }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install build dependencies
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq --no-install-recommends \
+            flatpak bubblewrap \
+            imagemagick librsvg2-common librsvg2-bin \
+            wget binutils ca-certificates desktop-file-utils \
+            xvfb x11-utils \
+            >/dev/null
+
+      # Cache the flatpak deployment tree (~2 GB: Pitivi + GNOME runtime
+      # + codecs). Saves ~3-4 minutes per run after the first.
+      - name: Cache flatpak deployments
+        uses: actions/cache@v5
+        with:
+          path: ~/.local/share/flatpak
+          # Bust the cache when build.sh changes (it picks the flatpak
+          # ref and may install different things).
+          key: flatpak-${{ inputs.arch }}-${{ hashFiles('build/appimage/build.sh') }}
+          restore-keys: |
+            flatpak-${{ inputs.arch }}-
+
+      - name: Build AppImage
+        id: build
+        env:
+          ARCH: ${{ inputs.arch }}
+          VARIANT: ${{ inputs.variant }}
+        run: |
+          set -euo pipefail
+          extra_args=()
+          [ "$VARIANT" = "lean" ] && extra_args+=(--lean)
+          ./build/appimage/build.sh "${extra_args[@]}" --out .
+
+          # build.sh emits Pitivi-<version>-<arch>.AppImage. Rename to
+          # include the variant so the release page can carry both.
+          src="$(ls Pitivi-*-${ARCH}.AppImage)"
+          ver="$(echo "$src" | sed -E 's/Pitivi-(.+)-[^-]+\.AppImage/\1/')"
+          dst="Pitivi-${ver}-${VARIANT}-${ARCH}.AppImage"
+          mv "$src" "$dst"
+          sha256sum "$dst" > "${dst}.sha256"
+
+          echo "artifact=$dst" >> "$GITHUB_OUTPUT"
+          ls -lh "$dst" "${dst}.sha256"
+
+      # Smoke test: extract the AppImage (CI runners have no FUSE),
+      # spawn it under Xvfb, wait up to 30 s for a window titled
+      # "Pitivi" to appear. Failure aborts the workflow.
+      - name: Smoke test
+        env:
+          ARTIFACT: ${{ steps.build.outputs.artifact }}
+        run: |
+          set -euo pipefail
+          ./"$ARTIFACT" --appimage-extract >/dev/null
+          xvfb-run -a -s "-screen 0 1280x720x24" bash -c '
+            ./squashfs-root/AppRun >appimage.log 2>&1 &
+            APP_PID=$!
+            for i in $(seq 1 30); do
+              sleep 1
+              if xwininfo -tree -root 2>/dev/null \
+                 | grep -qE "\"Pitivi\""; then
+                echo "OK: Pitivi window appeared after ${i}s"
+                kill "$APP_PID" 2>/dev/null || true
+                exit 0
+              fi
+            done
+            echo "FAIL: no Pitivi window after 30s"
+            echo "--- AppImage stderr ---"
+            cat appimage.log || true
+            kill "$APP_PID" 2>/dev/null || true
+            exit 1
+          '
+          rm -rf squashfs-root
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ steps.build.outputs.artifact }}
+          path: |
+            ${{ steps.build.outputs.artifact }}
+            ${{ steps.build.outputs.artifact }}.sha256
+          retention-days: ${{ inputs.retention-days }}
+          if-no-files-found: error

--- a/.github/workflows/ci-appimage.yml
+++ b/.github/workflows/ci-appimage.yml
@@ -1,0 +1,39 @@
+# CI: build & smoke-test the AppImage on every PR/push that touches the
+# packaging files. The full matrix (2 archs × 2 variants = 4 jobs) runs in
+# parallel; failures are independent so a broken --lean doesn't mask a
+# broken --full.
+name: CI / AppImage
+
+on:
+  pull_request:
+    branches: [master]
+    paths:
+      - 'build/appimage/**'
+      - '.github/workflows/ci-appimage.yml'
+      - '.github/workflows/_appimage-build.yml'
+  push:
+    branches: [master]
+    paths:
+      - 'build/appimage/**'
+      - '.github/workflows/ci-appimage.yml'
+      - '.github/workflows/_appimage-build.yml'
+  # Allow manual runs from the Actions tab.
+  workflow_dispatch:
+
+# Cancel in-progress runs of the same PR/branch when a new push comes in.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build & test
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [x86_64, aarch64]
+        variant: [full, lean]
+    uses: ./.github/workflows/_appimage-build.yml
+    with:
+      arch: ${{ matrix.arch }}
+      variant: ${{ matrix.variant }}

--- a/.github/workflows/release-appimage.yml
+++ b/.github/workflows/release-appimage.yml
@@ -1,0 +1,102 @@
+# Release: pushed `appimage-v*` tag → build the full matrix, then create
+# (or update) a GitHub release attaching every AppImage + its sha256.
+name: Release / AppImage
+
+on:
+  push:
+    tags:
+      - 'appimage-v*'
+  # Useful for re-running a release after an artifact upload glitch
+  # without having to delete and re-push the tag.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing tag to release (e.g. appimage-v2023.03.1)
+        required: true
+
+permissions:
+  contents: write   # required to create releases / upload assets
+
+jobs:
+  build:
+    name: Build
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [x86_64, aarch64]
+        variant: [full, lean]
+    uses: ./.github/workflows/_appimage-build.yml
+    with:
+      arch: ${{ matrix.arch }}
+      variant: ${{ matrix.variant }}
+      # Releases keep the artifacts forever via the Release page; the
+      # per-run artifact only needs to live long enough for the release
+      # job to download it.
+      retention-days: 1
+
+  release:
+    name: Publish release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Resolve tag
+        id: tag
+        run: |
+          if [ "${GITHUB_REF}" = "refs/tags/${GITHUB_REF#refs/tags/}" ]; then
+            echo "name=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+          else
+            echo "name=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Download all built AppImages
+        uses: actions/download-artifact@v8
+        with:
+          path: artifacts
+
+      # Each artifact comes back inside its own subdirectory; flatten so
+      # `gh release create` sees a single list of files.
+      - name: Flatten artifact tree
+        run: |
+          set -euo pipefail
+          mkdir -p release
+          find artifacts -type f \( -name '*.AppImage' -o -name '*.sha256' \) \
+              -exec mv {} release/ \;
+          echo "--- release/ contents ---"
+          ls -lh release/
+
+      - name: Create or update release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.tag.outputs.name }}
+        run: |
+          set -euo pipefail
+          notes=$(cat <<EOF
+          Auto-built portable AppImages for Pitivi.
+
+          Each tag publishes 4 builds:
+
+          | Arch | Variant | Approx size | Notes |
+          |---|---|---|---|
+          | x86_64 / aarch64 | full | ~540 MB | Complete bundle, in-app help included. |
+          | x86_64 / aarch64 | lean | ~388 MB | WebKit + JS engines + \`__pycache__\` stripped. No in-app help viewer (online help on pitivi.org still works). |
+
+          Each AppImage ships with a \`.sha256\` checksum file alongside.
+          Build instructions and runtime requirements:
+          [\`build/appimage/README.md\`](https://github.com/${{ github.repository }}/blob/${TAG}/build/appimage/README.md).
+          EOF
+          )
+
+          # If the release already exists (manual re-run, retry…), upload
+          # extra assets to it instead of failing.
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists; uploading assets."
+            gh release upload "$TAG" release/* --clobber
+          else
+            gh release create "$TAG" \
+              --title "$TAG" \
+              --notes "$notes" \
+              release/*
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,70 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Development environment
+
+All build/test/run commands must execute inside the project's Flatpak sandbox. The sandbox is entered by sourcing the env script, which sets up aliases that wrap commands with `ptvenv` (the sandbox runner at `build/flatpak/pitivi-flatpak`):
+
+```
+$ . bin/pitivi-env        # sets up the (ptv-flatpak) prompt and aliases
+```
+
+Initial sandbox creation can take hours. After a fresh sandbox is built, the script tells you to **close and reopen the terminal** so the aliases are picked up. Update the sandbox with `ptvenv --update`.
+
+If you cannot enter the sandbox, prefix any command with `ptvenv` directly (e.g. `ptvenv ninja -C mesonbuild/`). Running Python tools on the host will fail because GStreamer/GES typelibs and the Pitivi-specific GI overrides only exist inside the sandbox.
+
+## Common commands
+
+All of these assume you are inside `(ptv-flatpak)`:
+
+- `pitivi` — run Pitivi from the working tree (`PITIVI_DEVELOPMENT=1` is set automatically).
+- `setup` — one-time: create `mesonbuild/` (`mkdir mesonbuild; ptvenv meson mesonbuild/ --prefix=/app --libdir=lib`).
+- `build` — alias for `ninja -C mesonbuild/`. Required after editing C code in `pitivi/coptimizations/`, the `bin/pitivi.in` launcher, or `pitivi/configure.py.in` (these regenerate `.py` files).
+- `binstall` — `ninja -C mesonbuild/ install`. Needed to see translations or anything that has to be installed into the sandbox prefix.
+- `ptvtests` — run the unit test suite (wraps `gst-validate-launcher tests/ptv_testsuite.py --dump-on-failure`).
+- `ptvtests -L` — list all tests.
+- `ptvtests -t <pattern>` — run a subset. The pattern matches module / class / method substrings, e.g. `ptvtests -t test_project`, `ptvtests -t TestProjectManager`, `ptvtests -t test_loading_missing_project_file`.
+- `ptvtests --timeout-factor 10` — useful when a test legitimately needs more time (e.g. while debugging).
+- `ptvenv tests/validate-tests/runtests` — run integration tests (GstValidate scenarios under `tests/validate-tests/scenarios/`).
+- `pre-commit run --all-files` — run all configured linters (also runs automatically on commit via the symlinked `pre-commit.hook`).
+
+`PITIVI_VSCODE_DEBUG=1 pitivi` (or the same with `ptvtests`) starts a `debugpy` listener on port 5678 and waits for an attach.
+
+## Linting
+
+The pre-commit pipeline (configured in `.pre-commit-config.yaml`) runs: trailing-whitespace / EOF / encoding-pragma fixers, `reorder-python-imports`, `pydocstyle`, `flake8`, `mypy` (only on `pitivi/autoaligner.py`, `pitivi/clipproperties.py`, `pitivi/timeline/timeline.py`), `pylint` (config in `pylint.rc`), and `yamllint`. The pre-commit hook is automatically symlinked when entering the dev env, and it requires `PITIVI_REPO_DIR` to be set (i.e. the dev env must have been entered) — committing from a plain shell will fail.
+
+## Code architecture
+
+Pitivi is a Python/GTK frontend on top of GStreamer Editing Services (GES). It is **not** a self-contained Python app: it is glued together by GObject signals across several layers, all loaded via PyGObject (`gi.repository`).
+
+- **Backend stack** (not in this repo): GStreamer → Non-Linear Engine (gnonlin/nle) → GES → Pitivi. GES owns the timeline model, asset management, and rendering pipeline. Most "model" objects you'll see in code (`GES.Timeline`, `GES.Layer`, `GES.Clip`, `GES.TrackElement`, `GES.Project`) come from GES.
+- **Frontend** is the `pitivi/` Python package. Entry point is `bin/pitivi.in` (built into `bin/pitivi`), which sets paths, calls `pitivi.check.initialize_modules()` and `check_requirements()`, then runs `pitivi.application.Pitivi` (a `Gtk.Application`).
+- `pitivi/check.py` is the canonical list of hard and soft dependencies — read this if you need to know what versions/plugins Pitivi requires.
+- `pitivi/application.py` wires together the long-lived singletons hung off the `Pitivi` app object: `ProjectManager`, `EffectsManager`, `PluginManager`, `GlobalSettings`, `ShortcutsManager`, `UndoableActionLog`, `ProjectObserver`, `System`, `ThreadMaster`. Anything that needs cross-cutting state takes the `app` reference.
+- The UI is split into **perspectives** (`greeterperspective.py`, `editorperspective.py`, `trackerperspective.py`) hosted by `MainWindow` (`mainwindow.py`). The greeter is the project picker; the editor is the timeline + viewer + library + clip props.
+- `pitivi/timeline/` contains the timeline UI (canvas, layers, clip elements, ruler, previewers, markers). `pitivi/viewer/` is the preview area with overlays. `pitivi/clip_properties/` holds the per-clip property panels.
+- `pitivi/undo/` implements the undo/redo system. Edits to GES objects are observed by `ProjectObserver` and converted into `UndoableAction`s pushed onto `UndoableActionLog`. When adding features that mutate the timeline, register matching undo support here.
+- `pitivi/utils/` is a grab bag of cross-cutting helpers — note `loggable.py` (logging mixin used everywhere via `Loggable`), `pipeline.py` (Pitivi's wrapper around the GES rendering pipeline), `proxy.py` (proxy-asset/transcoding strategy), `validate.py` (action handlers for the integration scenarios), `timeline.py` (the `Zoomable` mixin and selection helpers).
+- C extensions live in `pitivi/coptimizations/` (currently `renderer.c` for the audio-envelope rendering of audio clips). Built by Meson into `pitivi/timeline/renderer.so`. Edit → `build` → re-run.
+- Plugins live under `plugins/`; the in-tree console plugin is the reference. They are loaded by `pitivi/pluginmanager.py`.
+
+## Coding conventions
+
+These are enforced by review and linters — they will save round-trips:
+
+- **Naming**: `snake_case` for functions, methods, attributes. Single underscore prefix = protected, double underscore = private.
+- **Callbacks** for GObject signals: name them `__<thing>_<event>_cb` (private) and prefix unused arguments with `unused_` (e.g. `def __pad_added_cb(self, unused_element, pad):`).
+- Docstrings follow the Google Python Style Guide (see `docs/Coding_style_guide.md`).
+- Keep lines reasonable; PEP-8 with `E402,E501,E722,F401,F841,W504` ignored in flake8.
+
+## Tests
+
+- Unit tests: `tests/test_*.py`. New tests should use the helpers in `tests/common.py` (see e.g. `common.create_pitivi_mock`, `common.create_timeline_container`). UI tests rely heavily on `unittest.mock`.
+- Pair logic file → test file by name: `pitivi/clip_properties/color.py` → `tests/test_clipproperties_color.py`. Undo-related logic for an area is usually covered both in its own file and in `tests/test_undo_*`.
+- Integration tests are GstValidate `.scenario` files under `tests/validate-tests/scenarios/`, driven by handlers in `pitivi/utils/validate.py`. New `.scenario` files are auto-generated each time Pitivi runs (see `application.write_action`).
+
+## Reference
+
+More detail in `docs/`: `HACKING.md`, `Testing.md`, `Debugging.md`, `Architecture.md`, `Coding_style_guide.md`, `GES.md`, `Plugins.md`.

--- a/build/appimage/.gitignore
+++ b/build/appimage/.gitignore
@@ -1,0 +1,2 @@
+_build/
+*.AppImage

--- a/build/appimage/AppRun
+++ b/build/appimage/AppRun
@@ -120,12 +120,20 @@ export XDG_DATA_DIRS="$APP/share:$RUNTIME/share:${XDG_DATA_DIRS:-/usr/local/shar
 export GSETTINGS_SCHEMA_DIR="$RUNTIME/share/glib-2.0/schemas"
 
 # GdkPixbuf loaders. We replaced the runtime's libgdk_pixbuf (glycin-based)
-# with the host's, so use the host's loaders.cache too — it includes a SVG
-# loader on virtually every Linux distro (librsvg2-common).
-HOST_PIXBUF_CACHE="/usr/lib/$ARCH_TRIPLE/gdk-pixbuf-2.0/2.10.0/loaders.cache"
-if [ -f "$HOST_PIXBUF_CACHE" ]; then
-    export GDK_PIXBUF_MODULE_FILE="$HOST_PIXBUF_CACHE"
-fi
+# with the host's, so use the host's loaders.cache too — it includes a
+# SVG loader on virtually every Linux distro (librsvg2-common). Path
+# layout varies: Debian/Ubuntu use /usr/lib/<arch-triple>/, Fedora/RHEL
+# use /usr/lib64/, Arch uses /usr/lib/. Probe each.
+for HOST_PIXBUF_CACHE in \
+    "/usr/lib/$ARCH_TRIPLE/gdk-pixbuf-2.0/2.10.0/loaders.cache" \
+    "/usr/lib64/gdk-pixbuf-2.0/2.10.0/loaders.cache" \
+    "/usr/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache"; do
+    if [ -f "$HOST_PIXBUF_CACHE" ]; then
+        export GDK_PIXBUF_MODULE_FILE="$HOST_PIXBUF_CACHE"
+        break
+    fi
+done
+unset HOST_PIXBUF_CACHE
 
 # GIO modules from the bundled runtime.
 export GIO_MODULE_DIR="$RUNTIME/lib/$ARCH_TRIPLE/gio/modules"

--- a/build/appimage/AppRun
+++ b/build/appimage/AppRun
@@ -1,0 +1,166 @@
+#!/bin/bash
+# AppRun for the Pitivi AppImage.
+#
+# Sets up the runtime environment so the bundled GNOME platform + Pitivi
+# can run on a host that does NOT have GNOME installed (e.g. XFCE, KDE,
+# barebones server).
+#
+# Layout inside the AppDir:
+#   ./app        — flatpak `org.pitivi.Pitivi` /app tree (hardlinks)
+#   ./runtime    — flatpak `org.gnome.Platform//N` /usr tree (hardlinks)
+#   ./codecs     — flatpak `org.pitivi.Pitivi.Codecs` extension
+#   ./host-libs  — selected host libs that override the runtime's (e.g. a
+#                  glycin-free libgdk_pixbuf so SVG/PNG load works)
+#   ./wrappers   — small shell wrappers prepended to PATH (currently bwrap)
+#   ./launcher.py — actual Python entry point (does the monkey-patches)
+#
+# Most quirks live in launcher.py; this script only sets env vars.
+
+set -e
+
+SELF="$(readlink -f "$0")"
+HERE="$(dirname "$SELF")"
+export APPDIR="${APPDIR:-$HERE}"
+
+RUNTIME="$APPDIR/runtime"
+APP="$APPDIR/app"
+CODECS="$APPDIR/codecs"
+
+# IMPORTANT: do all host-side bookkeeping BEFORE exporting LD_LIBRARY_PATH.
+# The bundled glibc is not ABI-compatible with the host's coreutils, so any
+# subprocess we spawn after this point would segfault.
+APPCACHE="${XDG_CACHE_HOME:-$HOME/.cache}/pitivi-appimage"
+mkdir -p "$APPCACHE"
+
+# Generate per-AppDir glycin loader configs that point at the bundled
+# loader binaries. The original configs (in $RUNTIME/share/glycin-loaders/)
+# point at /usr/libexec/glycin-loaders/ which is absent on a non-GNOME host.
+# Note: with the host libgdk_pixbuf overlay (host-libs/) glycin is no longer
+# in the image-loading path at all, so this is mostly belt-and-suspenders.
+GLYCIN_DIR="$APPCACHE/glycin-data/glycin-loaders/2+/conf.d"
+if [ -d "$RUNTIME/share/glycin-loaders/2+/conf.d" ]; then
+    mkdir -p "$GLYCIN_DIR"
+    for cfg in "$RUNTIME/share/glycin-loaders/2+/conf.d/"*.conf; do
+        [ -f "$cfg" ] || continue
+        sed "s|^Exec=/usr/libexec/glycin-loaders|Exec=$RUNTIME/libexec/glycin-loaders|" \
+            "$cfg" > "$GLYCIN_DIR/$(basename "$cfg")"
+    done
+fi
+
+# Detect the architecture-specific lib dir at runtime so future arches don't
+# need a code change.
+case "$(uname -m)" in
+    x86_64)  ARCH_TRIPLE=x86_64-linux-gnu  ; LD_NAME=ld-linux-x86-64.so.2 ;;
+    aarch64) ARCH_TRIPLE=aarch64-linux-gnu ; LD_NAME=ld-linux-aarch64.so.1 ;;
+    *)       echo "pitivi-appimage: unsupported architecture $(uname -m)" >&2 ; exit 1 ;;
+esac
+
+# Detect the bundled python version (e.g. python3.13). Must be done BEFORE
+# we export LD_LIBRARY_PATH below — the bundled glibc is newer than the
+# host's, so any sub-shell spawned after the export would load the bundled
+# libc through the host loader and segfault.
+PYDIR="$(ls -d "$APP"/lib/python3.* 2>/dev/null | head -1)"
+PYVER="$(basename "$PYDIR" 2>/dev/null)"
+
+# Library search path. host-libs/ wins over the runtime so we can override
+# specific libs (e.g. libgdk_pixbuf without glycin, see host-libs/README).
+export LD_LIBRARY_PATH="\
+$APPDIR/host-libs:\
+$APP/lib:\
+$APP/lib/codecs/lib:\
+$APP/lib/$ARCH_TRIPLE:\
+$RUNTIME/lib:\
+$RUNTIME/lib/$ARCH_TRIPLE:\
+$RUNTIME/lib/$ARCH_TRIPLE/pulseaudio:\
+$RUNTIME/lib64:\
+$CODECS/lib:\
+${LD_LIBRARY_PATH:-}"
+
+# GObject-Introspection typelibs.
+export GI_TYPELIB_PATH="\
+$APP/lib/girepository-1.0:\
+$RUNTIME/lib/girepository-1.0:\
+$RUNTIME/lib/$ARCH_TRIPLE/girepository-1.0:\
+${GI_TYPELIB_PATH:-}"
+
+# GStreamer plugins (Pitivi + codecs + bundled runtime base set).
+export GST_PLUGIN_SYSTEM_PATH="\
+$APP/lib/gstreamer-1.0:\
+$APP/lib/codecs/lib/gstreamer-1.0:\
+$RUNTIME/lib/gstreamer-1.0:\
+$CODECS/lib/gstreamer-1.0"
+unset GST_PLUGIN_PATH
+
+# GStreamer's plugin scanner (separate binary it fork-execs to introspect
+# plugins) and PTP helper. The scanner is normally fork-exec'd by GStreamer
+# but the host's ld-linux can't load the bundled scanner (newer libc), and
+# a bash-based wrapper around the runtime ld-linux doesn't work either
+# because the host's bash itself segfaults under our LD_LIBRARY_PATH
+# (libtinfo from the runtime is ABI-incompatible with the host bash).
+# GST_REGISTRY_FORK=no is the standard escape hatch: scan plugins
+# in-process. Slightly riskier (a broken plugin would crash Pitivi instead
+# of just failing the scan), but the bundled runtime is stable.
+export GST_REGISTRY_FORK=no
+unset GST_PLUGIN_SCANNER
+
+export GST_PTP_HELPER="$APP/libexec/gstreamer-1.0/gst-ptp-helper"
+[ -x "$GST_PTP_HELPER" ] || \
+    export GST_PTP_HELPER="$RUNTIME/lib/$ARCH_TRIPLE/gstreamer-1.0/gst-ptp-helper"
+
+# Per-AppImage GStreamer registry, so we don't poison the host's
+# ~/.cache/gstreamer-1.0 with paths that disappear when the AppImage moves.
+export GST_REGISTRY="$APPCACHE/registry.bin"
+
+# Glycin (image loader) data dir, with our patched configs.
+export GLYCIN_DATA_DIR="$APPCACHE/glycin-data"
+
+# XDG dirs: bundled themes/icons/schemas first, host's last so the user's
+# customisations still win.
+export XDG_DATA_DIRS="$APP/share:$RUNTIME/share:${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
+export GSETTINGS_SCHEMA_DIR="$RUNTIME/share/glib-2.0/schemas"
+
+# GdkPixbuf loaders. We replaced the runtime's libgdk_pixbuf (glycin-based)
+# with the host's, so use the host's loaders.cache too — it includes a SVG
+# loader on virtually every Linux distro (librsvg2-common).
+HOST_PIXBUF_CACHE="/usr/lib/$ARCH_TRIPLE/gdk-pixbuf-2.0/2.10.0/loaders.cache"
+if [ -f "$HOST_PIXBUF_CACHE" ]; then
+    export GDK_PIXBUF_MODULE_FILE="$HOST_PIXBUF_CACHE"
+fi
+
+# GIO modules from the bundled runtime.
+export GIO_MODULE_DIR="$RUNTIME/lib/$ARCH_TRIPLE/gio/modules"
+
+# Frei0r video effects (Pitivi-bundled).
+export FREI0R_PATH="$APP/lib/frei0r-1"
+
+# Python path. The runtime's site-packages must NOT be on PYTHONPATH:
+# it ships a newer PyGObject whose `gi.overrides` import a `gi.module`
+# API the app's older copy doesn't expose. We use the APP's `gi` and only
+# the runtime's stdlib (which lives in lib/python3.X/, not site-packages).
+# PYVER was detected above, before any LD_LIBRARY_PATH export.
+export PYTHONPATH="\
+$APP/lib/$PYVER/site-packages:\
+$APP/lib/pitivi/python:\
+$APP/lib/pitivi/python/pitivi/timeline:\
+${PYTHONPATH:-}"
+
+# PATH so bundled `gst-inspect-1.0` etc. resolve to the runtime/app, and
+# our shell wrappers (currently the bwrap shim) win over the host versions.
+export PATH="$APPDIR/wrappers:$APP/bin:$RUNTIME/bin:$PATH"
+
+# Pitivi's "I'm running uninstalled" flag must be off — this AppImage is
+# the installed copy from its own perspective.
+unset PITIVI_DEVELOPMENT
+
+# Use the bundled python (built against the runtime libs). The bundled glibc
+# may be newer than the host's, so we MUST invoke the runtime's ld-linux
+# instead of letting the host loader try to load a newer libc.
+LD="$RUNTIME/lib64/$LD_NAME"
+[ -e "$LD" ] || LD="$RUNTIME/lib/$LD_NAME"
+# Exported so wrappers/ scripts can re-exec sub-processes through the
+# same loader (currently used by wrappers/gst-plugin-scanner).
+export PITIVI_LD="$LD"
+
+SCRIPT="${PITIVI_APPIMAGE_SCRIPT:-$APPDIR/launcher.py}"
+exec "$LD" --library-path "$LD_LIBRARY_PATH" \
+    "$RUNTIME/bin/python3" "$SCRIPT" "$@"

--- a/build/appimage/README.md
+++ b/build/appimage/README.md
@@ -1,0 +1,322 @@
+---
+short-description: Building a portable AppImage of Pitivi
+...
+
+# Pitivi AppImage
+
+A self-contained, portable Pitivi binary that runs on any Linux desktop —
+including XFCE, KDE, MATE, LXQt, plain X11, etc. — **without** requiring
+the GNOME runtime to be installed on the target system. Everything Pitivi
+needs (GTK, GES, GStreamer, Python, codecs, locale data, ~1.7 GB of GNOME
+platform) is bundled inside a single ~550 MB executable.
+
+## Quick start
+
+From the repository root:
+
+```
+./build/appimage/build.sh
+```
+
+This produces `Pitivi-<version>-<arch>.AppImage` in the current directory.
+The first run takes a few minutes (it pulls the published Pitivi from
+Flathub if it isn't already installed); subsequent runs take ~30 s.
+
+To run the AppImage:
+
+```
+./Pitivi-2023.03-x86_64.AppImage
+```
+
+If the target host has FUSE 2 installed (most desktops do), the AppImage
+mounts itself and launches directly. Otherwise, fall back to:
+
+```
+./Pitivi-2023.03-x86_64.AppImage --appimage-extract-and-run
+```
+
+## Build script options
+
+```
+./build/appimage/build.sh [options]
+```
+
+| Option | Effect |
+|---|---|
+| `--out DIR` | Write the `.AppImage` to `DIR` instead of the current directory. |
+| `--keep-appdir` | Keep `_build/AppDir/` for inspection (1.6 GB of hardlinks). |
+| `--no-flatpak-install` | Skip `flatpak install`; reuse the already-installed `org.pitivi.Pitivi` (handy for offline builds). |
+| `--comp <c>` | squashfs compression: `zstd` (default; only one the modern appimagetool's bundled mksquashfs supports), `xz` / `gzip` (require an external mksquashfs and aren't always available), `none` (debug). |
+| `--lean` | Drop bundle bits Pitivi doesn't strictly need (~165 MB saved). See "Size optimisations" below. |
+| `-h`, `--help` | Show help. |
+
+### Size optimisations
+
+| Build | Final AppImage | Trade-off |
+|---|---|---|
+| `--comp zstd` (current default) | ~540 MB | Default since the modern appimagetool only ships zstd. Comparable ratio to xz with much faster decompression. |
+| `--comp zstd --lean` | **~390 MB** | See list below. Fully functional Pitivi; only the in-app help viewer is lost. |
+
+`--lean` removes:
+
+- **WebKit + JS engines + libyelp** (~270 MB): Pitivi never imports
+  WebKit; the only consumer in the bundle is `libyelp` (the offline
+  help viewer). After `--lean` the in-app help opens nothing, but the
+  online help on pitivi.org still works.
+- **`__pycache__/` directories** (~130 MB): pre-compiled Python
+  bytecode. Removed; CPython recreates them on first import. The first
+  launch after `--lean` is slightly slower, then identical.
+- **Static libs (`*.a`), headers (`include/`), docs (`share/doc`,
+  `share/man`, `share/gtk-doc`, `share/devhelp`, `share/info`)** and
+  the LibreOffice **`mythes`** thesaurus (~30 MB): never used at runtime.
+
+Environment overrides:
+
+| Variable | Effect |
+|---|---|
+| `PITIVI_REF` | Bundle a different flatpak ref (default `org.pitivi.Pitivi//stable`). E.g. `PITIVI_REF=org.pitivi.Pitivi//beta`. |
+| `PITIVI_HOST_PIXBUF` | Path to the host `libgdk_pixbuf-2.0.so.0` to bundle as overlay (default: auto-detected via `uname -m`). |
+
+## What gets bundled
+
+`build.sh` doesn't compile Pitivi: it pulls the published Flathub artifact
+(`org.pitivi.Pitivi`) and the GNOME runtime it depends on, then re-packages
+them as an AppImage. Layout inside the AppImage:
+
+```
+AppDir/
+├── AppRun                  bash entry point — sets env vars, exec's python
+├── launcher.py             Python entry point — monkey-patches and boots Pitivi
+├── org.pitivi.Pitivi.{desktop,svg}  required by appimagetool
+├── app/                    flatpak `/app` tree (Pitivi + its bundled libs)
+├── runtime/                flatpak `/usr` tree (GNOME platform 50 base)
+├── codecs/                 `org.pitivi.Pitivi.Codecs` extension (optional)
+├── host-libs/              host-distro libs that override the runtime's
+│                           (currently: libgdk_pixbuf-2.0 sans glycin)
+└── wrappers/               shell wrappers prepended to PATH
+    └── bwrap               sandbox shim used by libglycin (safety net)
+```
+
+## Auto-detection
+
+The build script and the AppImage's `AppRun` together try to discover as
+much as possible at runtime so the bundle works on a wide range of hosts
+without ever editing files in the hardlinked flatpak tree.
+
+### What `build.sh` discovers automatically
+
+| Item | How | Failure mode |
+|---|---|---|
+| Architecture | `uname -m` | Aborts on anything other than `x86_64`/`aarch64`. |
+| Pitivi deployment path | `flatpak info --user --show-location` | Aborts with a clear message if the flatpak isn't installed. |
+| Bundled runtime ref | Parsed from the flatpak's `metadata` (`runtime=…`) | Aborts if the metadata can't be parsed or the runtime isn't installed. |
+| Runtime deployment path | `flatpak info --show-location` on the parsed ref | Aborts if not installed. |
+| Codecs extension | `flatpak info` on `<id>.Codecs` | Built without codecs if absent (warns with `<none>`). |
+| Pitivi version (for the output filename) | `flatpak info \| awk '/Version:/'` | Falls back to `snapshot`. |
+| Host `libgdk_pixbuf-2.0.so.0` to overlay | `/usr/lib/$ARCH_TRIPLE/libgdk_pixbuf-2.0.so.0` (overridable via `PITIVI_HOST_PIXBUF`) | Warns and skips the overlay; AppImage will fall back to the runtime's glycin-based loader. |
+| Host gdk-pixbuf version | `strings` on the overlaid lib | Warns if older than 2.42 (potential ABI mismatch with bundled GTK). |
+| Build tools (`flatpak`, `convert`, `wget`, `find`, `sed`, `install`) | `command -v` | Aborts with a per-tool message naming the package to install. |
+| `bwrap` on the build host (optional) | `command -v bwrap` | Warns; only matters because the *target* host needs it for glycin. |
+| ImageMagick SVG delegate | `convert -list delegate` | Warns; SVG→PNG fallbacks are skipped, AppImage relies on the target host's librsvg2. |
+| Disk space | `df -kP` of `_build/` | Warns below 2 GB free. |
+| Python version inside the runtime | `ls $RUNTIME/bin/python3.*` | Aborts if the runtime ships none. |
+| `appimagetool` | Cached at `_build/appimagetool`; downloaded on first run | Re-fetched if the cached binary is missing. |
+
+### What `AppRun` discovers at every launch
+
+| Item | How |
+|---|---|
+| `APPDIR` | `readlink -f $0` (works through symlinks, mounted AppImage, or `--appimage-extract-and-run`). |
+| Architecture + matching `ld-linux` filename | `uname -m`. |
+| Bundled Python version | `ls $APP/lib/python3.*` (so a runtime bump from python3.13 → 3.14 needs no script change). |
+| `gst-plugin-scanner` | App's `libexec` first, runtime's as fallback. |
+| `gst-ptp-helper` | Same. |
+| `ld-linux` location | `lib64/` first, then `lib/`. |
+| Host `gdk-pixbuf` `loaders.cache` | Used if present (`/usr/lib/$ARCH_TRIPLE/gdk-pixbuf-2.0/2.10.0/loaders.cache`). |
+| Glycin loader configs | Re-rendered on every launch under `$XDG_CACHE_HOME/pitivi-appimage/glycin-data/` so the `Exec=` line points at the *current* `$APPDIR/runtime/libexec/...`. |
+
+### What `launcher.py` does at import time
+
+| Action | Why |
+|---|---|
+| Monkey-patches `pitivi.configure.LIBDIR` / `PKGDATADIR`. | The flatpak bakes `/app` into them; we replace them in memory rather than editing the file on disk (it's hardlinked into the user's flatpak install). |
+| Re-injects the app's `gi.overrides` directory. | The runtime's PyGObject overrides assume a newer `gi.module` API than the app's older copy ships — we want the app's overrides to win. |
+| Wraps `GdkPixbuf.Pixbuf.new_from_file_at_size` with a silent `.svg` → `.png` fallback. | If the target host lacks librsvg2, we transparently load the PNG sibling rendered at build time. |
+
+### What is **not** auto-detected
+
+These are limitations worth being honest about:
+
+- **Target-host glibc version.** The bundled runtime ships glibc 2.42; if
+  the target's glibc is much older we route through the runtime's own
+  `ld-linux`, but sub-processes spawned by GStreamer still go through the
+  host loader. In practice this is fine on any glibc 2.35+ desktop, but
+  we don't actively probe.
+- **Target-host `bwrap`.** The bundled `bwrap` shim assumes the host has
+  bubblewrap installed. If it doesn't, glycin loads silently fail (the
+  bundled `libgdk_pixbuf` overlay normally avoids glycin entirely, but
+  any code path that goes through `libglycin` directly will fail).
+- **Target-host `librsvg2-common`.** Without it, the host
+  `loaders.cache` won't have an SVG loader. `launcher.py` falls back to
+  pre-rendered PNGs for Pitivi pixmaps; arbitrary SVG assets a user
+  drops into a project would still fail to load.
+- **Cross-distro libgdk_pixbuf ABI.** We bundle whatever the *build*
+  host has. The script warns if it looks older than 2.42, but doesn't
+  refuse — verifying ABI compat with the bundled GTK 4.x is left to a
+  smoke test.
+- **Other libs that may need the same overlay treatment.** Only
+  `libgdk_pixbuf` is currently overlaid. Future runtimes may pull in
+  more sandboxed delegations (à la glycin) that need similar handling.
+
+## Build host requirements
+
+Hard:
+
+- `flatpak` 1.12+
+- ImageMagick (`convert`)
+- `wget`
+- coreutils, findutils, sed
+- ~3 GB free disk during the build
+- Filesystem that supports hardlinks across the `_build/` directory and
+  the user's `~/.local/share/flatpak/` directory (typically same fs).
+
+Soft:
+
+- `bubblewrap` (only used for the smoke test on the build host; the
+  bundled `bwrap` shim invokes whatever `bwrap` is on the *target* host)
+- `librsvg2-bin` or any ImageMagick build with an SVG delegate, so
+  step 5 of the build can render PNG fallbacks. Without it, the
+  AppImage relies on `librsvg2-common` being present on the target.
+
+## Target host requirements
+
+The AppImage tries hard to be portable. Realistically, expect to need:
+
+- A glibc-based Linux desktop (≥ 2.35 in practice).
+- X11 or XWayland, plus DBus and PulseAudio/PipeWire if you want sound.
+- `librsvg2-common` (any modern desktop has it; without it, SVG icons
+  fall back to pre-rendered PNGs but other SVG assets won't load).
+- `bubblewrap` (`bwrap`), present on most desktops as part of flatpak's
+  dependency chain. Optional in practice — the bundled
+  `libgdk_pixbuf` overlay avoids the only code path that needs it.
+- Working OpenGL drivers (system Mesa or the proprietary NVIDIA driver).
+  We deliberately don't bundle GL extensions; using the host's GL stack
+  produces ~500 MB savings and avoids driver mismatches.
+- FUSE 2 to run the AppImage directly. Without it,
+  `--appimage-extract-and-run` works as a fallback.
+
+## How it works
+
+The build doesn't compile Pitivi: it pulls the published Flathub artifact
+and re-packages it. Three files do the heavy lifting:
+
+- **`build.sh`** — composes the AppDir by **hardlinking** the deployed
+  flatpak trees, layers a host `libgdk_pixbuf` overlay (see below),
+  renders PNG fallbacks for SVG pixmaps, and runs `appimagetool`.
+- **`AppRun`** — bash entry point. It only sets environment variables
+  (`LD_LIBRARY_PATH`, `GI_TYPELIB_PATH`, `GST_PLUGIN_SYSTEM_PATH`,
+  `XDG_DATA_DIRS`, `GDK_PIXBUF_MODULE_FILE`, `PYTHONPATH`, …) and execs
+  the bundled python via the **runtime's** `ld-linux`. The bundled glibc
+  is newer than typical hosts, so the host loader can't load it.
+- **`launcher.py`** — Python entry point. Does the filesystem-fragile
+  work in memory rather than patching files in the hardlinked tree (see
+  the "What `launcher.py` does at import time" table above).
+
+### Why a host `libgdk_pixbuf` overlay?
+
+The GNOME 50 runtime's `libgdk_pixbuf-2.0` is linked against
+`libglycin`, which sandboxes every image load in `bwrap`. The sandbox
+bind-mounts the host's `/usr` and execs
+`/usr/libexec/glycin-loaders/...` — a path that doesn't exist on a
+non-GNOME host. We therefore ship the build host's own
+`libgdk_pixbuf-2.0.so.0` (without glycin) under `host-libs/` and put it
+first on `LD_LIBRARY_PATH`. The shipped lib has to be ABI-compatible
+with the runtime's GTK; the build host's gdk-pixbuf is normally fine
+(2.42+).
+
+### Why never modify hardlinked files?
+
+`build.sh` hardlinks the user's `~/.local/share/flatpak/` deployment
+into `_build/AppDir/`. Editing any hardlinked file via in-place writes
+(e.g. `python open(p, 'w')`, `gzip -f`, …) corrupts the user's flatpak
+install too. All run-time fixups therefore go through `launcher.py`
+monkey-patches; the only files we *create* in the AppDir are net-new
+PNG siblings of existing SVGs (which can't collide).
+
+## Files
+
+```
+build/appimage/
+├── README.md          this file
+├── build.sh           main build script
+├── AppRun             AppDir entry point (bash)
+├── launcher.py        Python entry point (monkey-patches + boot)
+├── wrappers/
+│   └── bwrap          glycin sandbox shim (safety net)
+└── _build/            build artifacts; gitignored
+    ├── AppDir/        hardlinked composition (deleted unless --keep-appdir)
+    └── appimagetool   cached on first run
+```
+
+## Multi-arch status
+
+`x86_64` and `aarch64` are wired in both the build script and the CI
+matrix. Other architectures abort upfront. `aarch64` is only useful if
+Flathub publishes `org.pitivi.Pitivi/aarch64/stable`; verify with
+`flatpak remote-info flathub org.pitivi.Pitivi//stable` before tagging
+a release.
+
+## Continuous integration & releases
+
+GitHub Actions workflows under `.github/workflows/`:
+
+- **`ci-appimage.yml`** runs on every PR and push to `master` that
+  touches `build/appimage/**`. Builds the full 2×2 matrix (x86_64 ×
+  aarch64) × (full × lean) and smoke-tests each AppImage under Xvfb.
+  Failures are independent so a broken `--lean` doesn't mask a broken
+  `--full`. Artifacts are kept 14 days.
+- **`release-appimage.yml`** runs when a tag matching `appimage-v*`
+  is pushed (e.g. `appimage-v2023.03.1`). Builds the same matrix and
+  publishes a GitHub release with the four AppImages and their
+  `.sha256` checksums attached.
+- **`_appimage-build.yml`** is the reusable inner workflow both call
+  to do the actual build + smoke test for one (arch, variant) cell.
+
+Naming convention for release artifacts:
+`Pitivi-<flatpak-version>-<variant>-<arch>.AppImage`.
+
+To cut a release: tag a commit on `master` with `appimage-v*` and push
+the tag. CI publishes the release automatically.
+
+## Caveats
+
+- The bundled tree is whatever Flathub currently ships, so the AppImage
+  inherits Flathub's release cadence. To bump, run
+  `flatpak update --user org.pitivi.Pitivi` and re-run `build.sh`.
+- The AppImage is ~540 MB with default zstd compression, or ~390 MB
+  with `--lean` (squashfs of a 1.6 GB / 1.2 GB AppDir respectively).
+- The bundled GNOME runtime carries its own glibc; sub-processes
+  spawned by GStreamer inherit the host loader. On hosts older than the
+  runtime's glibc, expect occasional warnings (e.g. `gst-plugin-scanner`
+  complaints) — typically benign for the editor itself.
+- This is a re-packaging of the Flathub build, not a from-source
+  Pitivi build. For a full development setup, see
+  [docs/HACKING.md](../../docs/HACKING.md).
+
+## Troubleshooting
+
+- **AppImage segfaults immediately**: the bundled glibc may be too new
+  for the host loader. The `AppRun` already routes the main `python` via
+  the runtime's `ld-linux`; if the segfault is later, look for a
+  sub-process (gst-plugin-scanner, etc.) hitting the same problem.
+- **No window appears, no Python traceback**: most likely the host
+  `libgdk_pixbuf` overlay was bundled from a too-old build host. Try
+  rebuilding from a host with libgdk_pixbuf 2.42+, or override via
+  `PITIVI_HOST_PIXBUF=/path/to/libgdk_pixbuf-2.0.so.0`.
+- **Pitivi opens but icons are missing**: target host probably lacks
+  `librsvg2-common`. Install it, or rely on the PNG fallbacks (which
+  cover Pitivi's bundled pixmaps but not arbitrary SVG assets).
+- **`Loader process exited early`** in stderr: a glycin loader failed
+  inside the sandbox. The libgdk_pixbuf overlay should sidestep this
+  for normal image loads; if it persists, a code path is calling
+  `libglycin` directly. Check that `bwrap` is installed on the host.

--- a/build/appimage/README.md
+++ b/build/appimage/README.md
@@ -188,22 +188,58 @@ Soft:
   step 5 of the build can render PNG fallbacks. Without it, the
   AppImage relies on `librsvg2-common` being present on the target.
 
-## Target host requirements
+## Target host compatibility
 
-The AppImage tries hard to be portable. Realistically, expect to need:
+**The desktop environment doesn't matter.** GNOME, XFCE, KDE, Cinnamon,
+MATE, LXQt, Sway, i3 — all work the same way, because the AppImage
+bundles its own GTK4 + Adwaita and uses the host's fonts / DBus /
+OpenGL drivers (interfaces stable across DEs). What matters is what
+the host system provides at the libc / system-library level.
 
-- A glibc-based Linux desktop (≥ 2.35 in practice).
-- X11 or XWayland, plus DBus and PulseAudio/PipeWire if you want sound.
-- `librsvg2-common` (any modern desktop has it; without it, SVG icons
-  fall back to pre-rendered PNGs but other SVG assets won't load).
-- `bubblewrap` (`bwrap`), present on most desktops as part of flatpak's
-  dependency chain. Optional in practice — the bundled
-  `libgdk_pixbuf` overlay avoids the only code path that needs it.
-- Working OpenGL drivers (system Mesa or the proprietary NVIDIA driver).
-  We deliberately don't bundle GL extensions; using the host's GL stack
-  produces ~500 MB savings and avoids driver mismatches.
-- FUSE 2 to run the AppImage directly. Without it,
-  `--appimage-extract-and-run` works as a fallback.
+### Hard requirements (AppImage won't start without these)
+
+| Requirement | Minimum | Why |
+|---|---|---|
+| **Architecture** | `x86_64` or `aarch64` | The only arches we build. |
+| **glibc** | 2.35+ (Ubuntu 22.04, Debian 12, Fedora 36+, RHEL 9) | Sub-processes (GStreamer helpers etc.) use the host's `ld-linux`, which then loads the bundled libc 2.42 via `LD_LIBRARY_PATH`. Mismatched versions segfault. |
+| **DBus session bus** | running | GTK4 / GIO require it. |
+| **X11 or Wayland session** | working | GTK4 needs a display server (XWayland is fine). |
+| **OpenGL drivers** | system Mesa or proprietary NVIDIA | We deliberately don't bundle GL extensions (saves ~500 MB and avoids driver mismatches). The video preview won't render without them. |
+
+### Soft requirements (AppImage runs but with degraded features)
+
+| Requirement | If missing |
+|---|---|
+| **`librsvg2-common`** | Host SVG loading is unavailable. Pitivi's bundled SVG pixmaps are covered by pre-rendered PNG siblings (rendered at build time); arbitrary SVG assets a user drops into a project would fail to load. |
+| **`bubblewrap` (`bwrap`)** | Only matters if anything still calls `libglycin` directly. The host `libgdk_pixbuf` overlay normally avoids glycin entirely. |
+| **PulseAudio or PipeWire** | No audio. |
+| **FUSE 2** | The AppImage can't mount itself; users have to invoke it with `--appimage-extract-and-run` (or extract once via `--appimage-extract`). |
+| **Active icon theme that contains `org.pitivi.Pitivi`** | The launcher's `Gtk.IconTheme.load_icon` wrapper falls back to the bundled hicolor icon, so this is purely cosmetic. |
+
+### Distros known to work
+
+| Distro | Status |
+|---|---|
+| Ubuntu 22.04, 24.04, 25.04 | ✅ tested (build + smoke test) |
+| Fedora 38+, including 43 | ✅ tested (after the icon-theme fallback fix) |
+| Debian 12 (Bookworm), 13 (Trixie) | ✅ very likely (glibc 2.36+) |
+| Linux Mint 21+, Pop!\_OS 22.04+, Manjaro, Arch, EndeavourOS | ✅ very likely |
+| openSUSE Tumbleweed, Leap 15.5+ | ✅ likely |
+| RHEL/CentOS/Rocky/Alma 9 | ⚠️ glibc 2.34 — at the edge, untested, may work |
+| RHEL 8, CentOS 8, Ubuntu 20.04 | ❌ glibc 2.28/2.31, too old |
+| Alpine, Void Linux | ❌ musl libc, not glibc |
+| Anything ARM-32 (`armhf`) | ❌ not built |
+
+### Self-check before downloading
+
+```
+ldd --version | head -1                # need >= 2.35
+uname -m                               # need x86_64 or aarch64
+ldconfig -p | grep -E 'librsvg|libfuse' | head
+```
+
+If glibc ≥ 2.35, arch is x86_64 or aarch64, and `librsvg` + `libfuse`
+appear in the output, the AppImage should run.
 
 ## How it works
 

--- a/build/appimage/build.sh
+++ b/build/appimage/build.sh
@@ -205,15 +205,46 @@ install -m 0644 "$SCRIPT_DIR/launcher.py" "$APPDIR/launcher.py"
 install -d                                  "$APPDIR/wrappers"
 install -m 0755 "$SCRIPT_DIR/wrappers/bwrap" "$APPDIR/wrappers/bwrap"
 
-# Drop GIO modules that are broken in the bundled GNOME 50 runtime: the
-# shipped libgvfsdbus.so references g_mount_spec_get_is_valid which the
-# co-shipped libgio-2.0 doesn't actually export, so loading it fails with
-# an undefined-symbol warning at every Pitivi launch. gvfs only matters
-# for accessing remote filesystems (smb://, sftp://, …) which Pitivi
-# doesn't normally use, so the cleanest fix is to remove the module.
+# Drop GIO modules that have unresolvable dependencies in our bundle.
+# The GNOME runtime ships gvfs-* modules that reference libgvfscommon.so
+# (and similar gvfs internals) which aren't bundled — at every load
+# attempt the user gets "Failed to load module: libgvfscommon.so: cannot
+# open shared object file". Pitivi doesn't need gvfs (remote filesystems
+# like smb://, sftp://) so we remove every broken module here.
+#
 # `rm` on a hardlink only unlinks our copy; the user's flatpak install
 # stays intact.
-rm -f "$APPDIR/runtime/lib/$ARCH_TRIPLE/gio/modules/libgvfsdbus.so"
+GIO_MODULES_DIR="$APPDIR/runtime/lib/$ARCH_TRIPLE/gio/modules"
+if [ -d "$GIO_MODULES_DIR" ]; then
+    removed=0
+    for mod in "$GIO_MODULES_DIR"/*.so; do
+        [ -f "$mod" ] || continue
+        broken_dep=""
+        for dep in $(objdump -p "$mod" 2>/dev/null \
+                     | awk '/NEEDED/ {print $2}'); do
+            # Already shipped by the bundled runtime?
+            for d in "$APPDIR/runtime/lib/$ARCH_TRIPLE" \
+                     "$APPDIR/runtime/lib" "$APPDIR/runtime/lib64" \
+                     "$APPDIR/host-libs"; do
+                [ -e "$d/$dep" ] && continue 2
+            done
+            # Glibc family — provided by every host loader.
+            case "$dep" in
+                libc.so.*|libm.so.*|libdl.so.*|libpthread.so.*|\
+                librt.so.*|libresolv.so.*|libgcc_s.so.*|ld-linux*) \
+                    continue ;;
+            esac
+            broken_dep="$dep"
+            break
+        done
+        if [ -n "$broken_dep" ]; then
+            echo "    drop GIO module $(basename "$mod")  (needs $broken_dep)"
+            rm -f "$mod"
+            removed=$((removed+1))
+        fi
+    done
+    [ "$removed" -gt 0 ] && echo "    dropped $removed broken GIO module(s)"
+fi
 
 # Required by appimagetool: top-level .desktop + matching icon.
 cp "$APPDIR/app/share/applications/${PITIVI_ID}.desktop" "$APPDIR/"

--- a/build/appimage/build.sh
+++ b/build/appimage/build.sh
@@ -1,0 +1,436 @@
+#!/bin/bash
+# Build a standalone Pitivi AppImage from the published Flathub deployment.
+#
+# Strategy: install (or use) `org.pitivi.Pitivi` from Flathub --user, then
+# hardlink its /app + bundled GNOME runtime tree into an AppDir, layer in a
+# host libgdk_pixbuf to sidestep glycin, render PNG fallbacks for SVG icons,
+# and pack everything with appimagetool. The actual fixups are done at run
+# time by AppRun + launcher.py — files in the flatpak deployment are NEVER
+# modified in place.
+#
+# Usage:
+#   ./build.sh [--out DIR] [--keep-appdir] [--no-flatpak-install]
+#
+# Run with --help for the full option list.
+
+set -euo pipefail
+
+usage() {
+    cat <<EOF
+Usage: $0 [options]
+
+Options:
+  --out DIR              Write the AppImage to DIR (default: current dir).
+  --keep-appdir          Don't delete _build/AppDir after packing.
+  --no-flatpak-install   Skip 'flatpak install', use what's already there.
+  --comp <zstd|gzip|xz|none>
+                         squashfs compression (default: zstd).
+                         zstd = current default; only one supported by
+                                the bundled mksquashfs in modern
+                                appimagetool. Excellent ratio + fast
+                                decompress.
+                         gzip = legacy. May or may not be supported
+                                depending on appimagetool version.
+                         xz   = legacy. Same caveat as gzip.
+                         none = no compression (debug).
+  --lean                 Drop bundle bits Pitivi doesn't strictly need:
+                         WebKit + JS engines (~270 MB, breaks the in-app
+                         help viewer; online help still works), mythes,
+                         docs/man/headers/static libs (~30 MB), and the
+                         shipped __pycache__ (~130 MB; Python regenerates
+                         pyc on first use, slightly slower first launch).
+  -h, --help             Show this help.
+
+Environment overrides:
+  PITIVI_REF             flatpak ref to bundle (default: org.pitivi.Pitivi//stable).
+  PITIVI_HOST_PIXBUF     full path to a host libgdk_pixbuf-2.0.so.0 to use as
+                         overlay (default: auto-detected via uname -m).
+EOF
+}
+
+# ---------- args -----------
+OUT_DIR="."
+KEEP_APPDIR=0
+DO_INSTALL=1
+COMP="zstd"
+LEAN=0
+PITIVI_REF="${PITIVI_REF:-org.pitivi.Pitivi//stable}"
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --out)                 OUT_DIR="$2"; shift 2 ;;
+        --keep-appdir)         KEEP_APPDIR=1; shift ;;
+        --no-flatpak-install)  DO_INSTALL=0; shift ;;
+        --comp)                COMP="$2"; shift 2 ;;
+        --lean)                LEAN=1; shift ;;
+        -h|--help)             usage; exit 0 ;;
+        *) echo "unknown arg: $1" >&2; usage >&2; exit 64 ;;
+    esac
+done
+
+case "$COMP" in
+    gzip|xz|zstd|none) ;;
+    *) echo "invalid --comp: $COMP (use gzip|xz|zstd|none)" >&2; exit 64 ;;
+esac
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORK_DIR="$SCRIPT_DIR/_build"
+APPDIR="$WORK_DIR/AppDir"
+
+# ---------- 0. environment audit ----------
+echo "[0/6] auditing build host..."
+
+# Architecture is the only thing we need before anything else, because the
+# rest of the script branches on it.
+ARCH="$(uname -m)"
+case "$ARCH" in
+    x86_64)  ARCH_TRIPLE=x86_64-linux-gnu ;;
+    aarch64) ARCH_TRIPLE=aarch64-linux-gnu ;;
+    *) echo "unsupported architecture: $ARCH" >&2; exit 1 ;;
+esac
+echo "    arch         : $ARCH ($ARCH_TRIPLE)"
+
+# Required tools. We treat each one as a separate, named requirement so the
+# error message tells the user exactly what to install.
+need() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        echo "missing tool '$1' — $2" >&2
+        exit 1
+    fi
+    echo "    $1$(printf '%*s' $((12 - ${#1})) '') : $(command -v "$1")"
+}
+need flatpak  "install flatpak (1.12+); needed to fetch the Pitivi deployment"
+need convert  "install ImageMagick; needed to render PNG fallbacks for SVG icons"
+need wget     "install wget; needed once to fetch appimagetool"
+need find     "install findutils"
+need sed      "install sed"
+need install  "install coreutils"
+need objdump  "install binutils; needed to walk host-libs deps"
+
+# Optional tools — warn but don't abort.
+opt() {
+    if command -v "$1" >/dev/null 2>&1; then
+        echo "    $1$(printf '%*s' $((12 - ${#1})) '') : $(command -v "$1") (optional)"
+    else
+        echo "    $1$(printf '%*s' $((12 - ${#1})) '') : NOT FOUND ($2)" >&2
+    fi
+}
+opt bwrap  "host bubblewrap; the AppImage's glycin sandbox needs it on the *target* host"
+
+# SVG renderer for the PNG fallbacks: prefer rsvg-convert (no policy
+# minefield), fall back to ImageMagick `convert` when missing. We check
+# both up front so we know which one to use later (step 5).
+SVG_RENDERER=""
+if command -v rsvg-convert >/dev/null 2>&1; then
+    SVG_RENDERER=rsvg-convert
+    echo "    rsvg-convert : $(command -v rsvg-convert)"
+elif convert -list format 2>/dev/null \
+     | awk '/^[ \t]+M?SVG[ \t]/{found=1} END{exit !found}'; then
+    SVG_RENDERER=convert
+    echo "    SVG renderer : ImageMagick convert"
+else
+    echo "    WARNING: no SVG renderer (rsvg-convert / convert with SVG" >&2
+    echo "    support) found; PNG fallbacks for Pitivi pixmaps won't be" >&2
+    echo "    generated. The AppImage will rely on the target host's" >&2
+    echo "    librsvg2-common. Install librsvg2-bin to fix." >&2
+fi
+
+# Make sure WORK_DIR exists before we use it (the disk-space check below
+# needs it). On a fresh checkout it doesn't.
+mkdir -p "$WORK_DIR"
+
+# Disk space — the AppDir is ~1.6 GB hardlinks (cheap), but mksquashfs
+# reads the whole thing and writes a ~600 MB AppImage; needing 2 GB free
+# at minimum is reasonable. Wrap in `|| true` so a transient `df` failure
+# doesn't kill the build under `set -e + pipefail`.
+FREE_KB="$(df -kP "$WORK_DIR" 2>/dev/null | awk 'NR==2{print $4}' || true)"
+if [ -n "${FREE_KB:-}" ] && [ "$FREE_KB" -lt $((2 * 1024 * 1024)) ]; then
+    echo "    WARNING: less than 2 GB free at $WORK_DIR; build may fail." >&2
+fi
+
+# ---------- 1. flatpak install/refresh ----------
+if [ "$DO_INSTALL" = 1 ]; then
+    if ! flatpak remote-list --user | grep -q '^flathub'; then
+        echo "[1/6] adding flathub remote (--user)..."
+        flatpak remote-add --user --if-not-exists flathub \
+            https://flathub.org/repo/flathub.flatpakrepo
+    fi
+    echo "[1/6] installing/updating $PITIVI_REF from flathub..."
+    flatpak install --user --noninteractive --or-update flathub "$PITIVI_REF" >/dev/null
+else
+    echo "[1/6] skipping flatpak install (--no-flatpak-install)"
+fi
+
+# ---------- 2. resolve deployment paths ----------
+echo "[2/6] resolving deployment paths..."
+PITIVI_ID="${PITIVI_REF%%//*}"
+PITIVI_DEP="$(flatpak info --user --show-location "$PITIVI_ID")/files"
+[ -d "$PITIVI_DEP" ] || { echo "Pitivi flatpak '$PITIVI_ID' not installed"; exit 1; }
+
+# The Pitivi flatpak metadata names which runtime + extensions it pulled in.
+RUNTIME_REF="$(grep -m1 '^runtime=' "$(dirname "$PITIVI_DEP")/metadata" | cut -d= -f2)"
+[ -n "$RUNTIME_REF" ] || { echo "could not parse runtime= from metadata"; exit 1; }
+RUNTIME_DEP="$(flatpak info --user --show-location "${RUNTIME_REF#runtime/}")/files"
+[ -d "$RUNTIME_DEP" ] || { echo "runtime $RUNTIME_REF not installed"; exit 1; }
+
+# Codecs extension is optional but recommended for full format coverage.
+CODECS_REF="${PITIVI_ID}.Codecs"
+CODECS_DEP=""
+if flatpak info --user "$CODECS_REF" >/dev/null 2>&1; then
+    CODECS_DEP="$(flatpak info --user --show-location "$CODECS_REF")/files"
+fi
+
+PITIVI_VER="$(flatpak info --user "$PITIVI_ID" | awk '/Version:/ {print $2}')"
+echo "    pitivi  : $PITIVI_DEP  (v$PITIVI_VER)"
+echo "    runtime : $RUNTIME_DEP  ($RUNTIME_REF)"
+echo "    codecs  : ${CODECS_DEP:-<none>}"
+
+# Sanity-check the runtime ships a python (the AppRun depends on it).
+if ! ls "$RUNTIME_DEP"/bin/python3.* >/dev/null 2>&1; then
+    echo "    ERROR: runtime ships no python3.*; nothing for AppRun to exec." >&2
+    exit 1
+fi
+
+# ---------- 3. compose AppDir ----------
+echo "[3/6] composing AppDir (hardlinks)..."
+rm -rf "$APPDIR"
+mkdir -p "$APPDIR"
+cp -al "$RUNTIME_DEP" "$APPDIR/runtime"
+cp -al "$PITIVI_DEP"  "$APPDIR/app"
+[ -n "$CODECS_DEP" ] && cp -al "$CODECS_DEP" "$APPDIR/codecs" || mkdir "$APPDIR/codecs"
+
+# Drop in our hand-written entry points + wrappers (overwriting any prior
+# stale copies).
+install -m 0755 "$SCRIPT_DIR/AppRun"      "$APPDIR/AppRun"
+install -m 0644 "$SCRIPT_DIR/launcher.py" "$APPDIR/launcher.py"
+install -d                                  "$APPDIR/wrappers"
+install -m 0755 "$SCRIPT_DIR/wrappers/bwrap" "$APPDIR/wrappers/bwrap"
+
+# Drop GIO modules that are broken in the bundled GNOME 50 runtime: the
+# shipped libgvfsdbus.so references g_mount_spec_get_is_valid which the
+# co-shipped libgio-2.0 doesn't actually export, so loading it fails with
+# an undefined-symbol warning at every Pitivi launch. gvfs only matters
+# for accessing remote filesystems (smb://, sftp://, …) which Pitivi
+# doesn't normally use, so the cleanest fix is to remove the module.
+# `rm` on a hardlink only unlinks our copy; the user's flatpak install
+# stays intact.
+rm -f "$APPDIR/runtime/lib/$ARCH_TRIPLE/gio/modules/libgvfsdbus.so"
+
+# Required by appimagetool: top-level .desktop + matching icon.
+cp "$APPDIR/app/share/applications/${PITIVI_ID}.desktop" "$APPDIR/"
+cp "$APPDIR/app/share/icons/hicolor/scalable/apps/${PITIVI_ID}.svg" "$APPDIR/"
+ln -sf "${PITIVI_ID}.svg" "$APPDIR/.DirIcon"
+sed -i 's|^Exec=.*|Exec=AppRun %U|; s|^TryExec=.*|TryExec=AppRun|' \
+    "$APPDIR/${PITIVI_ID}.desktop"
+
+# ---------- 4. host libgdk_pixbuf overlay ----------
+# Replace the runtime's libgdk_pixbuf (linked to libglycin, which sandboxes
+# loaders via bwrap and can't reach its bundled binaries on a non-GNOME
+# host) with the host distro's copy. We MUST NOT touch the runtime tree
+# itself (hardlinked into the user's flatpak install); instead we ship the
+# replacement under host-libs/ and put it first on LD_LIBRARY_PATH.
+echo "[4/6] staging host libgdk_pixbuf overlay..."
+mkdir -p "$APPDIR/host-libs"
+HOST_PIXBUF="${PITIVI_HOST_PIXBUF:-/usr/lib/$ARCH_TRIPLE/libgdk_pixbuf-2.0.so.0}"
+if [ -f "$HOST_PIXBUF" ]; then
+    cp -L "$HOST_PIXBUF" "$APPDIR/host-libs/libgdk_pixbuf-2.0.so.0"
+    # `strings` returns several version-shaped tokens (the ABI marker
+    # 2.10.0 and the real release 2.4X.Y). Pick the highest 2.4X.Y match.
+    PIXBUF_VER="$(strings "$APPDIR/host-libs/libgdk_pixbuf-2.0.so.0" \
+                  | grep -E '^2\.4[0-9]+\.[0-9]+$' | sort -V | tail -1)"
+    : "${PIXBUF_VER:=unknown}"
+    echo "    using $HOST_PIXBUF (v$PIXBUF_VER)"
+    if [ "$PIXBUF_VER" != unknown ]; then
+        minor="${PIXBUF_VER#2.}"; minor="${minor%%.*}"
+        if [ "${minor:-0}" -lt 42 ]; then
+            echo "    WARNING: host libgdk_pixbuf is older than 2.42; may be" >&2
+            echo "    ABI-incompatible with the bundled GTK." >&2
+        fi
+    fi
+
+    # Recursively bundle every NEEDED dep of the overlaid lib that is
+    # absent from the runtime. The build host's libgdk_pixbuf may pull in
+    # libs (e.g. libjpeg.so.8) that aren't shipped in the GNOME runtime
+    # nor present on the target host's distribution, which would break
+    # typelib resolution at run time.
+    #
+    # NEVER bundle the glibc core: bundling libc/libm/libpthread/ld-linux
+    # would require the *target* host's loader to load a possibly newer
+    # libc, which segfaults. The bundled runtime already ships its own
+    # full glibc set under runtime/lib/.
+    is_core() {
+        case "$1" in
+            libc.so.*|libm.so.*|libdl.so.*|libpthread.so.*|librt.so.*|\
+            libresolv.so.*|libnss_*|libutil.so.*|libcrypt.so.*|\
+            libanl.so.*|libBrokenLocale.so.*|libthread_db.so.*|\
+            ld-linux*|ld-musl-*|libgcc_s.so.*) return 0 ;;
+            *) return 1 ;;
+        esac
+    }
+    in_runtime() {
+        for d in "$APPDIR/runtime/lib/$ARCH_TRIPLE" \
+                 "$APPDIR/runtime/lib" "$APPDIR/runtime/lib64"; do
+            [ -e "$d/$1" ] && return 0
+        done
+        return 1
+    }
+    bundled_count=0; missing_count=0
+    queue=("libgdk_pixbuf-2.0.so.0")
+    declare -A seen=()
+    while [ ${#queue[@]} -gt 0 ]; do
+        lib="${queue[0]}"; queue=("${queue[@]:1}")
+        [ -n "${seen[$lib]:-}" ] && continue
+        seen[$lib]=1
+        [ -f "$APPDIR/host-libs/$lib" ] || continue
+        # objdump avoids the env-pollution risks of ldd
+        for dep in $(objdump -p "$APPDIR/host-libs/$lib" 2>/dev/null \
+                     | awk '/NEEDED/ {print $2}'); do
+            is_core "$dep" && continue
+            in_runtime "$dep" && continue
+            [ -f "$APPDIR/host-libs/$dep" ] && { queue+=("$dep"); continue; }
+            # find on host
+            host_path=""
+            for dir in "/usr/lib/$ARCH_TRIPLE" /usr/lib \
+                       "/lib/$ARCH_TRIPLE" /lib; do
+                if [ -f "$dir/$dep" ]; then
+                    host_path="$dir/$dep"; break
+                fi
+            done
+            if [ -n "$host_path" ]; then
+                cp -L "$host_path" "$APPDIR/host-libs/$dep"
+                echo "    bundled $dep  (from $host_path)"
+                bundled_count=$((bundled_count+1))
+                queue+=("$dep")
+            else
+                echo "    WARNING: dep '$dep' (needed by $lib) not found on host" >&2
+                missing_count=$((missing_count+1))
+            fi
+        done
+    done
+    if [ "$bundled_count" = 0 ] && [ "$missing_count" = 0 ]; then
+        echo "    no extra deps needed (runtime covers everything)"
+    else
+        echo "    bundled $bundled_count extra dep(s), $missing_count missing"
+    fi
+else
+    echo "    WARNING: $HOST_PIXBUF not found on build host; the AppImage" >&2
+    echo "    will fall back to the runtime's glycin-based loader and may" >&2
+    echo "    fail to load images on a host without GNOME libs." >&2
+fi
+
+# ---------- 5. render PNG fallbacks for Pitivi SVGs ----------
+# The runtime libgdk_pixbuf comes from a different distro than the target's
+# librsvg2-common; if SVG loading fails at run time, launcher.py falls back
+# to a sibling .png that we render here once at build time.
+echo "[5/6] rendering PNG fallbacks for SVG pixmaps..."
+PIXMAPS="$APPDIR/app/share/pitivi/pixmaps"
+made=0; failed=0
+render_svg_to_png() {
+    case "$SVG_RENDERER" in
+        rsvg-convert) rsvg-convert -w 128 -h 128 "$1" -o "$2" 2>/dev/null ;;
+        convert)      convert -background none -resize 128x128 "$1" "$2" 2>/dev/null ;;
+        *)            return 1 ;;
+    esac
+}
+if [ -n "$SVG_RENDERER" ]; then
+    while IFS= read -r svg; do
+        png="${svg%.svg}.png"
+        if [ ! -e "$png" ]; then
+            if render_svg_to_png "$svg" "$png"; then
+                made=$((made+1))
+            else
+                failed=$((failed+1))
+            fi
+        fi
+    done < <(find "$PIXMAPS" -name '*.svg')
+    echo "    rendered $made new PNGs, $failed failed (via $SVG_RENDERER)"
+else
+    echo "    skipped: no SVG renderer available"
+fi
+
+# ---------- 5b. trim (--lean only) ----------
+# Removing files inside the AppDir is safe: hardlinks share inodes but
+# `rm` only unlinks the AppDir's directory entry; the user's flatpak
+# deployment keeps its own hardlinks and stays intact.
+if [ "$LEAN" = 1 ]; then
+    echo "[5b/6] --lean: trimming non-essential files..."
+    before=$(du -sb "$APPDIR" | awk '{print $1}')
+
+    # WebKit + its JS engines + the in-app help viewer (libyelp). Pitivi
+    # never imports WebKit; only `libyelp` does, and we lose only the
+    # offline help viewer (online help via pitivi.org still works).
+    rm -f \
+        "$APPDIR/runtime/lib/$ARCH_TRIPLE"/libwebkit*.so* \
+        "$APPDIR/runtime/lib/$ARCH_TRIPLE"/libwebkitgtk*.so* \
+        "$APPDIR/runtime/lib/$ARCH_TRIPLE"/libjavascriptcoregtk*.so* \
+        "$APPDIR/runtime/lib/$ARCH_TRIPLE"/libmozjs*.so* \
+        "$APPDIR/runtime/lib/$ARCH_TRIPLE"/libyelp*.so* \
+        "$APPDIR/runtime/lib/$ARCH_TRIPLE"/girepository-1.0/{WebKit,JavaScriptCore,Yelp}*.typelib \
+        2>/dev/null || true
+
+    # Static libs and headers — never useful at runtime.
+    find "$APPDIR" -name '*.a' -delete 2>/dev/null
+    rm -rf "$APPDIR/runtime/include" "$APPDIR/app/include"
+
+    # Doc trees.
+    rm -rf \
+        "$APPDIR/runtime/share/doc" "$APPDIR/app/share/doc" \
+        "$APPDIR/runtime/share/man" "$APPDIR/app/share/man" \
+        "$APPDIR/runtime/share/gtk-doc" \
+        "$APPDIR/runtime/share/devhelp" \
+        "$APPDIR/runtime/share/info"
+
+    # Mythes (LibreOffice thesaurus) — Pitivi never uses it.
+    rm -rf "$APPDIR/runtime/share/mythes"
+
+    # Bytecode caches — Python recreates on first use; first launch is
+    # slightly slower but the AppImage shrinks by ~130 MB.
+    find "$APPDIR" -name '__pycache__' -type d -exec rm -rf {} + 2>/dev/null
+
+    after=$(du -sb "$APPDIR" | awk '{print $1}')
+    saved=$(( (before - after) / 1024 / 1024 ))
+    echo "    AppDir went from $((before/1024/1024)) MB to $((after/1024/1024)) MB (saved $saved MB)"
+fi
+
+# ---------- 6. pack ----------
+echo "[6/6] packing AppImage..."
+APPIMAGETOOL_DL="$WORK_DIR/appimagetool"
+if [ ! -x "$APPIMAGETOOL_DL" ]; then
+    # Use the active AppImage/appimagetool repo (NOT the deprecated
+    # AppImageKit). The old AppImageKit continuous build had a bug in
+    # arch detection that mistakenly treated `file`(1) outputs "aarch64"
+    # and "ARM aarch64" as separate architectures, causing aarch64
+    # builds to fail with a bogus "More than one architectures" message
+    # even when ARCH was exported. The new repo also ships a single
+    # static-pie ELF instead of a nested AppImage, so we can invoke it
+    # directly.
+    case "$ARCH" in
+        x86_64)  AT_URL="https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage" ;;
+        aarch64) AT_URL="https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-aarch64.AppImage" ;;
+    esac
+    echo "    fetching appimagetool from $AT_URL"
+    wget -q "$AT_URL" -O "$APPIMAGETOOL_DL"
+    chmod +x "$APPIMAGETOOL_DL"
+fi
+APPIMAGETOOL_BIN="$APPIMAGETOOL_DL"
+
+OUT_NAME="Pitivi-${PITIVI_VER:-snapshot}-${ARCH}.AppImage"
+mkdir -p "$OUT_DIR"
+# Pass --comp through to mksquashfs. Default zstd is the only compressor
+# the modern AppImage/appimagetool's bundled mksquashfs supports; gzip/xz
+# require an external mksquashfs build, which is fragile across distros.
+APPIMAGE_COMP_ARGS=()
+[ "$COMP" = none ] || APPIMAGE_COMP_ARGS=(--comp "$COMP")
+# Always export ARCH so the appimagetool sub-process picks the right
+# embedded runtime (its own arch sniffing fails on AppDirs that mix
+# native binaries with sandbox bits like glycin loaders).
+export ARCH
+"$APPIMAGETOOL_BIN" --no-appstream \
+    "${APPIMAGE_COMP_ARGS[@]}" "$APPDIR" "$OUT_DIR/$OUT_NAME"
+
+if [ "$KEEP_APPDIR" = 0 ]; then
+    rm -rf "$APPDIR"
+fi
+
+echo
+echo "Done: $OUT_DIR/$OUT_NAME"
+ls -lh "$OUT_DIR/$OUT_NAME"

--- a/build/appimage/build.sh
+++ b/build/appimage/build.sh
@@ -322,26 +322,39 @@ fi
 # librsvg2-common; if SVG loading fails at run time, launcher.py falls back
 # to a sibling .png that we render here once at build time.
 echo "[5/6] rendering PNG fallbacks for SVG pixmaps..."
-PIXMAPS="$APPDIR/app/share/pitivi/pixmaps"
 made=0; failed=0
 render_svg_to_png() {
     case "$SVG_RENDERER" in
-        rsvg-convert) rsvg-convert -w 128 -h 128 "$1" -o "$2" 2>/dev/null ;;
-        convert)      convert -background none -resize 128x128 "$1" "$2" 2>/dev/null ;;
+        rsvg-convert) rsvg-convert -w "$3" -h "$3" "$1" -o "$2" 2>/dev/null ;;
+        convert)      convert -background none -resize "${3}x${3}" "$1" "$2" 2>/dev/null ;;
         *)            return 1 ;;
     esac
 }
+# We render PNG siblings for two SVG locations:
+#   1. app/share/pitivi/pixmaps/  — Pitivi's bundled UI icons.
+#   2. app/share/icons/hicolor/scalable/apps/  — the app icon, which
+#      Pitivi loads via Gtk.IconTheme.load_icon. On hosts whose gdk-pixbuf
+#      can't find an SVG loader (Fedora/Arch path layout differs from
+#      Debian/Ubuntu, so our bundled loaders.cache misses), the launcher
+#      falls back to the PNG sibling.
 if [ -n "$SVG_RENDERER" ]; then
-    while IFS= read -r svg; do
-        png="${svg%.svg}.png"
-        if [ ! -e "$png" ]; then
-            if render_svg_to_png "$svg" "$png"; then
-                made=$((made+1))
-            else
-                failed=$((failed+1))
+    for src_pair in \
+        "$APPDIR/app/share/pitivi/pixmaps:128" \
+        "$APPDIR/app/share/icons/hicolor/scalable/apps:256"; do
+        dir="${src_pair%:*}"
+        size="${src_pair##*:}"
+        [ -d "$dir" ] || continue
+        while IFS= read -r svg; do
+            png="${svg%.svg}.png"
+            if [ ! -e "$png" ]; then
+                if render_svg_to_png "$svg" "$png" "$size"; then
+                    made=$((made+1))
+                else
+                    failed=$((failed+1))
+                fi
             fi
-        fi
-    done < <(find "$PIXMAPS" -name '*.svg')
+        done < <(find "$dir" -name '*.svg')
+    done
     echo "    rendered $made new PNGs, $failed failed (via $SVG_RENDERER)"
 else
     echo "    skipped: no SVG renderer available"

--- a/build/appimage/build.sh
+++ b/build/appimage/build.sh
@@ -243,7 +243,12 @@ if [ -d "$GIO_MODULES_DIR" ]; then
             removed=$((removed+1))
         fi
     done
-    [ "$removed" -gt 0 ] && echo "    dropped $removed broken GIO module(s)"
+    if [ "$removed" -gt 0 ]; then
+        echo "    dropped $removed broken GIO module(s)"
+        # giomodule.cache references the deleted modules; drop it so GIO
+        # regenerates the cache from the surviving .so files at startup.
+        rm -f "$GIO_MODULES_DIR/giomodule.cache"
+    fi
 fi
 
 # Required by appimagetool: top-level .desktop + matching icon.

--- a/build/appimage/launcher.py
+++ b/build/appimage/launcher.py
@@ -123,13 +123,32 @@ _orig_load_icon = Gtk.IconTheme.load_icon
 def _load_icon_with_hicolor_fallback(self, icon_name, size, flags):
     try:
         return _orig_load_icon(self, icon_name, size, flags)
-    except GLib.GError:
-        for ext in (".svg", ".png"):
-            cand = os.path.join(APP, "share", "icons", "hicolor",
-                                "scalable", "apps", f"{icon_name}{ext}")
-            if os.path.isfile(cand):
+    except GLib.GError as orig_err:
+        # Build a candidate list ordered by reliability: PNG first
+        # (universally supported by gdk-pixbuf without external loaders),
+        # SVG only as a last resort (requires librsvg2 to be discoverable
+        # via the host's loaders.cache, which our bundle can't always
+        # arrange — Fedora's path layout differs from Debian's). Try
+        # multiple subdirs because some icons live under fixed sizes
+        # rather than scalable/.
+        candidates = []
+        subdirs = ("scalable", "256x256", "128x128", "96x96",
+                   "64x64", "48x48", "32x32", "24x24", "16x16")
+        for sub in subdirs:
+            for ext in (".png", ".svg"):
+                candidates.append(os.path.join(
+                    APP, "share", "icons", "hicolor", sub, "apps",
+                    f"{icon_name}{ext}"))
+        for cand in candidates:
+            if not os.path.isfile(cand):
+                continue
+            try:
                 return _orig_new_from_file_at_size(cand, size, size)
-        raise
+            except GLib.GError:
+                # Loader rejected this file (typically SVG without a
+                # registered loader); try the next candidate.
+                continue
+        raise orig_err
 
 
 Gtk.IconTheme.load_icon = _load_icon_with_hicolor_fallback

--- a/build/appimage/launcher.py
+++ b/build/appimage/launcher.py
@@ -104,6 +104,34 @@ initialize_modules()
 if not check_requirements():
     sys.exit(2)
 
+
+# --- Gtk.IconTheme.load_icon fallback -----------------------------------
+# Some distros (notably Fedora with Adwaita) don't fall back to the
+# hicolor theme when an icon is missing from the active theme, so
+# Pitivi crashes loading its own app icon. Wrap load_icon so that on
+# failure we look in the bundled hicolor scalable/apps for an SVG/PNG
+# with the same name and load it directly.
+gi.require_version("Gtk", "4.0")
+from gi.repository import GLib, Gtk  # noqa: E402
+
+_orig_load_icon = Gtk.IconTheme.load_icon
+
+
+def _load_icon_with_hicolor_fallback(self, icon_name, size, flags):
+    try:
+        return _orig_load_icon(self, icon_name, size, flags)
+    except GLib.GError:
+        for ext in (".svg", ".png"):
+            cand = os.path.join(APP, "share", "icons", "hicolor",
+                                "scalable", "apps", f"{icon_name}{ext}")
+            if os.path.isfile(cand):
+                return _orig_new_from_file_at_size(cand, size, size)
+        raise
+
+
+Gtk.IconTheme.load_icon = _load_icon_with_hicolor_fallback
+
+
 signal.signal(signal.SIGINT, signal.SIG_DFL)
 
 from pitivi import application  # noqa: E402

--- a/build/appimage/launcher.py
+++ b/build/appimage/launcher.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+# Python entry point for the Pitivi AppImage.
+#
+# All filesystem-fragile fixups (path rewrites, override re-injection,
+# loader fallbacks) live HERE rather than in patched-on-disk files, so the
+# bundled flatpak deployment (which is hardlinked into the AppDir at build
+# time) is never modified in place.
+import gettext
+import glob
+import os
+import signal
+import sys
+
+try:
+    from ctypes import cdll
+    cdll.LoadLibrary("libX11.so").XInitThreads()
+except OSError:
+    pass
+
+APPDIR = os.environ["APPDIR"]
+APP = os.path.join(APPDIR, "app")
+RUNTIME = os.path.join(APPDIR, "runtime")
+
+
+def _runtime_python_lib():
+    """Return the runtime's `lib/python3.X` directory (whichever Python
+    version this AppImage was built against)."""
+    matches = sorted(glob.glob(os.path.join(RUNTIME, "lib", "python3.*")))
+    if not matches:
+        raise RuntimeError("No python3.* under {RUNTIME}/lib")
+    # Filter out site-packages style entries; we want the bare "python3.X".
+    return next(m for m in matches if os.path.basename(m).count(".") == 1)
+
+
+PY_LIB = _runtime_python_lib()
+PY_VER = os.path.basename(PY_LIB)  # e.g. "python3.13"
+
+# Make Pitivi importable. The bundled flatpak app installs Pitivi under
+# $APP/lib/pitivi/python.
+sys.path.insert(0, os.path.join(APP, "lib", "pitivi", "python"))
+
+
+# --- gi.overrides ---------------------------------------------------------
+# The runtime ships a newer PyGObject than the app's site-packages. Its
+# overrides require a `gi.module` API that doesn't exist in the older copy
+# the app bundles. We use the APP's `gi` (older but matched to the app's
+# overrides) by NOT putting the runtime's site-packages on PYTHONPATH (the
+# AppRun arranges that). Re-inject the app's overrides path here defensively.
+import gi.overrides  # noqa: E402
+
+_app_overrides = os.path.join(APP, "lib", PY_VER, "site-packages",
+                              "gi", "overrides")
+if os.path.isdir(_app_overrides) and _app_overrides not in gi.overrides.__path__:
+    gi.overrides.__path__.insert(0, _app_overrides)
+
+
+# --- pitivi.configure relocation -----------------------------------------
+# `configure.py` is generated at flatpak build time with /app and /usr paths
+# baked in. We can't sed-patch it because it's hardlinked back to the user's
+# flatpak install — so monkey-patch in memory before any pitivi import that
+# captures the values.
+import pitivi.configure as _cfg  # noqa: E402
+
+_cfg.LIBDIR = os.path.join(APP, "lib")
+_cfg.PKGDATADIR = os.path.join(APP, "share", "pitivi")
+
+
+# --- i18n ---------------------------------------------------------------
+gettext.bindtextdomain("pitivi", os.path.join(APP, "share", "locale"))
+gettext.textdomain("pitivi")
+
+
+# --- GdkPixbuf SVG fallback ---------------------------------------------
+# AppRun replaces the runtime's libgdk_pixbuf with the host's (no glycin),
+# but if the host happens to lack librsvg2-common, SVG loads will fail.
+# Many Pitivi pixmaps are SVG; we ship pre-rendered .png siblings (built by
+# build.sh) and silently fall back to the PNG when an SVG load throws.
+import gi  # noqa: E402
+gi.require_version("GdkPixbuf", "2.0")
+from gi.repository import GdkPixbuf  # noqa: E402
+
+_orig_new_from_file_at_size = GdkPixbuf.Pixbuf.new_from_file_at_size
+
+
+def _png_fallback_load(filename, *args, **kwargs):
+    if isinstance(filename, str) and filename.endswith(".svg"):
+        try:
+            return _orig_new_from_file_at_size(filename, *args, **kwargs)
+        except Exception:
+            png = filename[:-4] + ".png"
+            if os.path.exists(png):
+                return _orig_new_from_file_at_size(png, *args, **kwargs)
+            raise
+    return _orig_new_from_file_at_size(filename, *args, **kwargs)
+
+
+GdkPixbuf.Pixbuf.new_from_file_at_size = staticmethod(_png_fallback_load)
+
+
+# --- Boot Pitivi --------------------------------------------------------
+from pitivi.check import check_requirements, initialize_modules  # noqa: E402
+
+initialize_modules()
+if not check_requirements():
+    sys.exit(2)
+
+signal.signal(signal.SIGINT, signal.SIG_DFL)
+
+from pitivi import application  # noqa: E402
+
+application.Pitivi().run(sys.argv)

--- a/build/appimage/launcher.py
+++ b/build/appimage/launcher.py
@@ -111,7 +111,10 @@ if not check_requirements():
 # Pitivi crashes loading its own app icon. Wrap load_icon so that on
 # failure we look in the bundled hicolor scalable/apps for an SVG/PNG
 # with the same name and load it directly.
-gi.require_version("Gtk", "4.0")
+#
+# Don't call gi.require_version here: initialize_modules() above has
+# already locked Pitivi's Gtk major version (currently 3.0), and re-
+# requiring a different one raises ValueError.
 from gi.repository import GLib, Gtk  # noqa: E402
 
 _orig_load_icon = Gtk.IconTheme.load_icon

--- a/build/appimage/wrappers/bwrap
+++ b/build/appimage/wrappers/bwrap
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Wrapper for bwrap, used by libglycin to sandbox image loaders.
+#
+# Glycin (used by GdkPixbuf in the GNOME 50 runtime) builds a bwrap command
+# that bind-mounts the host's /usr and execs /usr/libexec/glycin-loaders/...
+# That path is absent on a non-GNOME host. Our build.sh patches the loader
+# configs to point inside $APPDIR/runtime, and this wrapper bind-mounts
+# that directory into the sandbox so the binary is reachable from inside.
+#
+# With the host libgdk_pixbuf overlay (host-libs/) glycin is no longer in
+# the image-loading path, so this wrapper is currently a safety net for
+# any code still wired through libglycin directly.
+set -e
+
+REAL_BWRAP="${PITIVI_REAL_BWRAP:-/usr/bin/bwrap}"
+if [ ! -x "$REAL_BWRAP" ]; then
+    REAL_BWRAP="$(PATH="${PATH#*$(dirname "$0"):}" command -v bwrap || true)"
+fi
+if [ -z "$REAL_BWRAP" ]; then
+    echo "pitivi-appimage: bwrap not found on host; cannot sandbox glycin loader" >&2
+    exit 127
+fi
+
+# We expect $APPDIR to be present in the env when libglycin spawns us
+# (libglycin invokes us BEFORE the --clearenv inside the sandbox applies).
+if [ -n "${APPDIR:-}" ] && [ -d "$APPDIR/runtime" ]; then
+    exec "$REAL_BWRAP" --ro-bind "$APPDIR/runtime" "$APPDIR/runtime" "$@"
+fi
+exec "$REAL_BWRAP" "$@"


### PR DESCRIPTION
## TL;DR

Adds an opt-in `build/appimage/` packaging path that wraps the existing
Flathub deployment as a portable AppImage runnable on any Linux desktop
without a GNOME runtime installed. Plus GitHub Actions to build and
release it. The maintenance burden on the project is meant to be zero
(see "Maintenance" below), but as you mentioned upstream isn't
interested in supporting another packaging route, so I've also
suggested an alternative at the bottom — feel free to close, no harm
done.

## The story

I needed Pitivi on a non-GNOME Linux desktop (XFCE/Ubuntu, no flatpak)
without pulling in the whole GNOME runtime locally. The existing
Flathub artifact already contains everything needed; the only thing
missing was a thin wrapper that turns it into something AppImage can
mount on any host. So I wrote that wrapper.

I started with 15 incremental commits as I iterated against the
GitHub-hosted aarch64 runners. Squashed to 3 logical commits before
asking for a second look.

## What this PR adds

| Commit | Scope |
|---|---|
| `build: add portable AppImage packaging` | `build/appimage/` (build script, AppRun, Python launcher, README, bwrap shim) |
| `ci: add GitHub Actions to build & release` | `.github/workflows/` (PR/push CI matrix + tag-triggered release) |
| `docs: add CLAUDE.md` | Optional — happy to drop if you'd rather not carry it |

The README at `build/appimage/README.md` covers the design choices
(why hardlinks, why a host `libgdk_pixbuf` overlay, why a runtime
`ld-linux`, etc.) and an auto-detection table.

Output sizes (Pitivi 2023.03):

| Variant | x86_64 | aarch64 |
|---|---|---|
| `full` | 499 MB | 479 MB |
| `--lean` | 364 MB | 347 MB |

`--lean` strips WebKit + JS engines (only consumed by libyelp, the
in-app help viewer), pre-compiled `__pycache__/`, and a few other
non-essential bits.

## Maintenance

The CI pipeline is self-contained:

- `ci-appimage.yml` only runs when `build/appimage/**` or the
  workflows themselves change — no impact on regular Pitivi commits.
- `release-appimage.yml` only runs on `appimage-v*` tags, so it never
  collides with upstream's own `2023.x` tag scheme.
- Both bundle Flathub-published artifacts at build time, so AppImage
  releases automatically follow whatever Flathub is shipping.

In practice the project's only ongoing burden if merged is reviewing
incoming AppImage-only PRs (rare). Tagging a release is a one-liner.

## If you'd rather not merge

Totally understand. The fork at `Wasabules/pitivi` works as-is; I can
keep maintaining it there and publish releases from the fork. The only
thing that would help users find it is a single line somewhere in
`README.md` or `docs/` (e.g. "Community-maintained AppImage builds:
<link>"). Happy to PR just that one line if it's something you'd
accept.

Either way, thanks for taking the time to look.